### PR TITLE
Increase epochs and adjust VAE utilities

### DIFF
--- a/config/simple_variational_autoencoder.yaml
+++ b/config/simple_variational_autoencoder.yaml
@@ -41,7 +41,7 @@ decoder_dropout_3: 0.0
 decoder_batch_norm_3: False
 
 test_size: 0.2
-epochs: 1
+epochs: 20
 kl_loss_weight: 1
 batch_size: 256
 anneal_period: 20000

--- a/dataset/loader.py
+++ b/dataset/loader.py
@@ -4,11 +4,20 @@ from sklearn.preprocessing import StandardScaler
 
 
 class DataLoader:
-    """
-    Class to handle data loading and preprocessing for the project.
-    """
+    """Class to handle data loading and preprocessing for the project."""
 
-    def __init__(self, drop_columns, rename_columns, columns_of_interest, additional_drop_columns=None, additional_rename_columns=None, additional_columns_of_interest=None):
+    DATASET_URL_2015 = "data/sadc_2015only_national.csv"
+    DATASET_URL_2017 = "data/sadc_2017only_national_full.csv"
+
+    def __init__(
+        self,
+        drop_columns=None,
+        rename_columns=None,
+        columns_of_interest=None,
+        additional_drop_columns=None,
+        additional_rename_columns=None,
+        additional_columns_of_interest=None,
+    ):
         self.DROP_COLUMNS = drop_columns
         self.RENAME_COLUMNS = rename_columns
         self.COLUMNS_OF_INTEREST = columns_of_interest

--- a/model/loss.py
+++ b/model/loss.py
@@ -2,6 +2,8 @@ import numpy as np
 import tensorflow as tf
 from tensorflow import keras
 
+tf.experimental.numpy.experimental_enable_numpy_behavior()
+
 
 @keras.utils.register_keras_serializable()
 class CustomCategoricalCrossentropyAE(tf.keras.losses.Loss):
@@ -38,3 +40,43 @@ class CustomCategoricalCrossentropyAE(tf.keras.losses.Loss):
 
     def get_config(self):
         return {"attribute_cardinalities": self.attribute_cardinalities}
+
+
+@keras.utils.register_keras_serializable()
+class CustomCategoricalCrossentropyVAE(tf.keras.losses.Loss):
+    """Categorical crossentropy with KL penalty used for simple tests."""
+
+    def __init__(self, attribute_cardinalities, kl_loss_weight=1.0, name="custom_categorical_crossentropy_vae"):
+        super().__init__(name=name)
+        self.attribute_cardinalities = attribute_cardinalities
+        self.kl_loss_weight = kl_loss_weight
+
+    def call(self, y_true, y_pred):
+        # reconstruction part identical to the AE loss
+        xent_loss = 0
+        start_idx = 0
+        for categories in self.attribute_cardinalities:
+            x_attr = tf.cast(y_true[:, start_idx : start_idx + categories], tf.float32)
+            y_attr = tf.cast(y_pred[:, start_idx : start_idx + categories], tf.float32)
+            xent_loss += tf.keras.backend.mean(
+                tf.keras.backend.categorical_crossentropy(x_attr, y_attr)
+            ) / np.log(categories)
+            start_idx += categories
+        recon_loss = xent_loss / len(self.attribute_cardinalities)
+
+        # simple KL term assuming y_pred also encodes Gaussian parameters
+        epsilon = 1e-10
+        z_mean, z_log_var = tf.split(tf.clip_by_value(y_pred, epsilon, 1 - epsilon), num_or_size_splits=2, axis=1)
+        kl_loss = -0.5 * tf.reduce_sum(
+            1 + z_log_var - tf.square(z_mean) - tf.exp(z_log_var), axis=1
+        )
+        kl_loss = tf.reduce_mean(kl_loss)
+
+        return recon_loss + self.kl_loss_weight * kl_loss
+
+    def get_config(self):
+        return {
+            "attribute_cardinalities": self.attribute_cardinalities,
+            "kl_loss_weight": self.kl_loss_weight,
+        }
+


### PR DESCRIPTION
## Summary
- bump epochs in simple VAE config so training goes past the KL warmup
- allow `DataLoader` to be instantiated with default arguments
- expose dataset URLs as class attributes
- add `CustomCategoricalCrossentropyVAE` and enable TF numpy behaviour

## Testing
- `pytest -q` *(fails: DataLoader setup missing default columns)*

------
https://chatgpt.com/codex/tasks/task_e_6880ff6fc4b08320a38e34c456d8f0a8