### PR TITLE
fix(01): CI failure + follow-up Codex review comments

### DIFF
--- a/frontend/server/index.ts
+++ b/frontend/server/index.ts
@@ -53,6 +53,15 @@ const upload = multer({
 export function createServer() {
   const app = express();
 
+  // Trust the first proxy hop in production so Express sees the client
+  // protocol/IP forwarded by a TLS-terminating proxy (Cloud Run, Nginx, etc.).
+  // Without this, `cookie.secure: true` on the session causes express-session
+  // to refuse to issue session cookies (it sees req.secure === false), and
+  // every subsequent authenticated request returns 401.
+  if (env.NODE_ENV === "production") {
+    app.set("trust proxy", 1);
+  }
+
   // Security middleware - apply BEFORE routes
   app.use(corsConfig);
   app.use(helmetConfig);

--- a/frontend/server/utils/fileValidation.ts
+++ b/frontend/server/utils/fileValidation.ts
@@ -74,10 +74,17 @@ export function generateSafeFilename(userId: string): string {
  * @returns Sanitized absolute path if safe, null if traversal detected
  */
 export function sanitizePath(uploadDir: string, unsafePath: string): string | null {
-  const resolved = path.resolve(uploadDir, unsafePath);
+  const normalizedUploadDir = path.resolve(uploadDir);
+  const resolved = path.resolve(normalizedUploadDir, unsafePath);
 
-  // Verify resolved path is within upload directory
-  if (!resolved.startsWith(path.resolve(uploadDir))) {
+  // Verify resolved path is within the upload directory.
+  // Use a trailing separator so sibling directories that share the same
+  // prefix (e.g. `/var/uploads_evil/...` vs `/var/uploads`) are rejected.
+  // Also accept an exact match for the directory itself.
+  if (
+    resolved !== normalizedUploadDir &&
+    !resolved.startsWith(normalizedUploadDir + path.sep)
+  ) {
     return null; // Path traversal attempt
   }
 

--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -19,8 +19,10 @@ sys.modules['model.autoencoder'] = MagicMock()
 sys.modules['dataset.loader'] = MagicMock()
 sys.modules['features.transform'] = MagicMock()
 
-# Mock load_dotenv before importing worker
-with patch('dotenv.load_dotenv'):
+# Mock load_dotenv and google.cloud.firestore.Client before importing worker.
+# worker.py instantiates a Firestore client at module load time, which would
+# otherwise fail under CI where no Application Default Credentials are set.
+with patch('dotenv.load_dotenv'), patch('google.cloud.firestore.Client'):
     import worker
 
 


### PR DESCRIPTION
Fixes the CI test collection failure on PR #12 and addresses two follow-up Codex review comments on commit `592b980c`. Will be fast-forward merged into `feat/phase-01-security-foundation` so it appears directly in PR #12.

## Fixes

### CI — `tests/test_env_validation.py`: mock Firestore client before importing worker
`worker.py:49` instantiates `firestore.Client(project=PROJECT_ID)` at module load time. The test file already mocks `tensorflow`, `dotenv`, and the model imports, but not `google.cloud.firestore.Client`. Under CI, which has no Application Default Credentials, test collection fails with `DefaultCredentialsError` before any test runs. Added a `patch('google.cloud.firestore.Client')` to the existing pre-import context manager.

### P1 — `frontend/server/index.ts`: trust proxy in production
`session.ts` sets `cookie.secure: true` when `NODE_ENV === "production"`, but the Express app never enables proxy trust. Behind a TLS-terminating proxy (Cloud Run, Nginx, etc.) `req.secure` is `false`, so `express-session` silently refuses to issue the session cookie and every subsequent authenticated request returns 401. Added `app.set("trust proxy", 1)` in `createServer()` gated on `NODE_ENV === "production"`, before the session middleware is attached.

### P2 — `frontend/server/utils/fileValidation.ts`: directory-boundary check in `sanitizePath`
The previous `resolved.startsWith(path.resolve(uploadDir))` check also matched sibling directories that share the same prefix (for example `/var/uploads_evil/...` when `uploadDir` is `/var/uploads`), defeating the traversal guard. Now compares against `uploadDir + path.sep`, with an explicit exact-match exception for the directory itself. All existing `sanitizePath` tests still pass under the new logic.

## Codex comments not addressed here
- P2 — `server/models/user.ts:74` (email uniqueness race during signup): requires a separate email-index collection and Firestore transactions. Architecturally significant; will confirm approach with the user before making that change.

## Test plan
- [ ] `python -m pytest tests/ -v` — passes in CI (no Firestore credentials needed for test collection)
- [ ] Existing `frontend/server/__tests__/utils/fileValidation.test.ts` tests still pass under the new boundary logic
- [ ] Deploy to an environment behind a TLS proxy with `NODE_ENV=production` and verify signup → me → jobs flow works