### PR TITLE
fix(01): CI regression + follow-up Codex comments (round 2)

### DIFF
--- a/frontend/server/index.ts
+++ b/frontend/server/index.ts
@@ -15,6 +15,7 @@
 import "dotenv/config";
 import express from "express";
 import multer from "multer";
+import { v4 as uuidv4 } from "uuid";
 import { Storage } from "@google-cloud/storage";
 import { Firestore } from "@google-cloud/firestore";
 import { PubSub } from "@google-cloud/pubsub";
@@ -101,7 +102,11 @@ export function createServer() {
       }
 
       const originalName = req.file.originalname;
-      const uniqueId = `job_${Date.now()}_${Math.random().toString(36).substring(7)}`;
+      // Use a UUID v4 for the job id so it matches the `validateJobId` UUID
+      // check on /api/jobs/job-status/:id. The previous
+      // `job_<timestamp>_<random>` format got rejected at polling time,
+      // leaving the fallback upload flow internally inconsistent.
+      const uniqueId = uuidv4();
 
       // Generate safe filename (discard user-provided name)
       const safeFilename = generateSafeFilename((req as any).user.id);

--- a/frontend/server/middleware/rateLimits.ts
+++ b/frontend/server/middleware/rateLimits.ts
@@ -20,7 +20,13 @@ const userOrIpKeyGenerator = (req: Request): string => {
 /**
  * Upload rate limiter
  * Limits: 5 requests per 15 minutes per user
- * Prevents Vertex AI quota abuse
+ *
+ * Applied to endpoints that actually kick off a training job
+ * (/api/jobs/start-job and the /api/upload fallback). Prevents Vertex AI
+ * quota abuse. A separate, independent bucket (`uploadUrlLimiter`) is used
+ * for the cheap /upload-url step so that a normal 3-step upload flow
+ * consumes one slot from each bucket rather than halving the apparent
+ * "uploads per 15 min" budget.
  */
 export const uploadLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
@@ -29,6 +35,41 @@ export const uploadLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Upload limit exceeded. Try again in 15 minutes.' },
+});
+
+/**
+ * Signed-URL request rate limiter
+ * Limits: 5 requests per 15 minutes per user
+ *
+ * Applied to /api/jobs/upload-url. Kept as an independent bucket from
+ * `uploadLimiter` so a normal 3-step upload (one /upload-url call followed
+ * by one /start-job call) does not consume two slots from the same budget.
+ */
+export const uploadUrlLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5,
+  keyGenerator: userOrIpKeyGenerator,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many upload URL requests. Try again in 15 minutes.' },
+});
+
+/**
+ * Authentication rate limiter
+ * Limits: 10 requests per 15 minutes per IP
+ *
+ * Applied to login, signup, and password reset request/reset endpoints.
+ * Throttles online brute-force and credential-stuffing attacks while still
+ * accommodating legitimate users who mistype a password a few times. Keyed
+ * by IP only (not user ID) since unauthenticated requests have no user.
+ */
+export const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10,
+  keyGenerator: (req: Request): string => ipKeyGenerator(req),
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many authentication attempts. Try again in 15 minutes.' },
 });
 
 /**

--- a/frontend/server/routes/auth.ts
+++ b/frontend/server/routes/auth.ts
@@ -6,6 +6,7 @@
 import { Router, Request, Response } from 'express';
 import { passport, requireAuth } from '../middleware/auth';
 import { validateSignup, validateLogin } from '../middleware/validation';
+import { authLimiter } from '../middleware/rateLimits';
 import {
   createUser,
   createVerificationToken,
@@ -26,7 +27,7 @@ const router = Router();
  * POST /api/auth/signup
  * Create a new user account
  */
-router.post('/signup', validateSignup, async (req: Request, res: Response) => {
+router.post('/signup', authLimiter, validateSignup, async (req: Request, res: Response) => {
   try {
     const { email, password } = req.body;
 
@@ -57,7 +58,7 @@ router.post('/signup', validateSignup, async (req: Request, res: Response) => {
  * POST /api/auth/login
  * Authenticate user with email and password
  */
-router.post('/login', validateLogin, (req: Request, res: Response, next) => {
+router.post('/login', authLimiter, validateLogin, (req: Request, res: Response, next) => {
   passport.authenticate('local', (err: any, user: any, info: any) => {
     if (err) {
       logger.error('Login error', { error: err });
@@ -174,7 +175,7 @@ router.get('/verify-email', async (req: Request, res: Response) => {
  * Email sending is stubbed (logs to console) in v1
  * Always returns success to prevent email enumeration
  */
-router.post('/request-reset', async (req: Request, res: Response) => {
+router.post('/request-reset', authLimiter, async (req: Request, res: Response) => {
   try {
     const { email } = req.body;
 
@@ -207,7 +208,7 @@ router.post('/request-reset', async (req: Request, res: Response) => {
  * POST /api/auth/reset-password
  * Reset password with token
  */
-router.post('/reset-password', async (req: Request, res: Response) => {
+router.post('/reset-password', authLimiter, async (req: Request, res: Response) => {
   try {
     const { token, newPassword } = req.body;
 

--- a/frontend/server/routes/jobs.ts
+++ b/frontend/server/routes/jobs.ts
@@ -14,7 +14,7 @@ import { Firestore } from "@google-cloud/firestore";
 import { PubSub } from "@google-cloud/pubsub";
 import { v4 as uuidv4 } from "uuid";
 import { requireAuth } from '../middleware/auth';
-import { uploadLimiter, pollLimiter, downloadLimiter } from '../middleware/rateLimits';
+import { uploadLimiter, uploadUrlLimiter, pollLimiter, downloadLimiter } from '../middleware/rateLimits';
 import { validateJobId, validateUploadUrl, validateStartJob } from '../middleware/validation';
 import { generateSafeFilename } from '../utils/fileValidation';
 import { logger } from '../config/logger';
@@ -29,7 +29,7 @@ const BUCKET_NAME = process.env.GCS_BUCKET_NAME || "your-bucket-name";
 const TOPIC_ID = process.env.PUBSUB_TOPIC_ID || "your-topic-id";
 
 // 1. Get Signed URL for Upload
-router.post("/upload-url", requireAuth, uploadLimiter, validateUploadUrl, async (req, res) => {
+router.post("/upload-url", requireAuth, uploadUrlLimiter, validateUploadUrl, async (req, res) => {
   try {
     const { filename, contentType } = req.body;
     const jobId = uuidv4();

--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -13,17 +13,41 @@ import sys
 import os
 from unittest.mock import MagicMock, patch
 
-# Mock tensorflow and model imports before importing worker
-sys.modules['tensorflow'] = MagicMock()
-sys.modules['model.autoencoder'] = MagicMock()
-sys.modules['dataset.loader'] = MagicMock()
-sys.modules['features.transform'] = MagicMock()
+# Mock heavyweight imports before importing worker so the module loads quickly
+# and without GPU/TF/GCP dependencies.
+#
+# IMPORTANT: we capture and restore the previous sys.modules state after the
+# import. Otherwise pytest (which collects tests in alphabetical order) would
+# see these MagicMock entries when later test files do
+# `from features.transform import Table2Vector` or
+# `from model.autoencoder import AutoencoderModel`, causing cryptic failures
+# like `ValueError: not enough values to unpack (expected 2, got 0)` when
+# unpacking the result of a MagicMock call in tests/test_integration_pipeline.py.
+_MOCKED_MODULES = [
+    'tensorflow',
+    'model.autoencoder',
+    'dataset.loader',
+    'features.transform',
+]
+_saved_modules = {name: sys.modules.get(name) for name in _MOCKED_MODULES}
+
+for name in _MOCKED_MODULES:
+    sys.modules[name] = MagicMock()
 
 # Mock load_dotenv and google.cloud.firestore.Client before importing worker.
 # worker.py instantiates a Firestore client at module load time, which would
 # otherwise fail under CI where no Application Default Credentials are set.
 with patch('dotenv.load_dotenv'), patch('google.cloud.firestore.Client'):
     import worker
+
+# Restore sys.modules to its original state so other tests collected after
+# this file get the real modules when they do `from features.transform import ...`.
+for name in _MOCKED_MODULES:
+    saved = _saved_modules[name]
+    if saved is None:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = saved
 
 
 def test_validate_environment_raises_on_missing_google_cloud_project(monkeypatch):


### PR DESCRIPTION
Fixes the CI regression surfaced after the previous merge and addresses three new Codex review comments on commit `17640fa`. Will be fast-forwarded into `feat/phase-01-security-foundation` so the changes appear directly in PR #12.

## Fixes

### CI — `tests/test_env_validation.py`: stop polluting `sys.modules`
**Root cause:** The previous patch mocked `tensorflow`, `features.transform`, `model.autoencoder`, and `dataset.loader` by assigning `MagicMock()` into `sys.modules` at import time. Because pytest collects test files alphabetically, `test_env_validation.py` runs before `test_integration_pipeline.py`. When the integration test later did `from features.transform import Table2Vector` and `from model.factory import get_model` (which internally imports `model.autoencoder`), it silently received the `MagicMock` entries left in `sys.modules`. Every subsequent call — `Table2Vector(...)`, `AutoencoderModel(...)`, `trainer.train(...)` — returned `MagicMock` instances. Unpacking one of those at `trainer.py:18` (`X_train, X_test = self.model.split_train_test(...)`) produced exactly the error we saw:
```
ValueError: not enough values to unpack (expected 2, got 0)
```
I verified this locally by reproducing the unpacking error with a minimal `sys.modules` + `MagicMock` script.

**Fix:** capture the previous `sys.modules` state for the four mocked module names, install the mocks only for the duration of the `import worker` call, then restore (or `pop`) the entries so later test files get real imports.

### P1 — `server/middleware/rateLimits.ts` + `server/routes/auth.ts`: throttle auth endpoints
Added an `authLimiter` (10 requests per 15 min, keyed by IP) and applied it to `/signup`, `/login`, `/request-reset`, and `/reset-password`. Without this, an attacker could make unlimited password guesses from a single IP against real accounts now that the PR adds session-based auth with bcrypt password verification.

### P2 — `server/middleware/rateLimits.ts` + `server/routes/jobs.ts`: split upload budget
`uploadLimiter` was attached to both `/upload-url` and `/start-job`, so a single logical upload consumed two slots from the same 5/15min bucket, halving the effective budget. Added a dedicated `uploadUrlLimiter` (independent 5/15min bucket) and applied it to `/upload-url`. Now a normal 3-step upload takes one slot from each bucket and users get the apparent 5 uploads per 15 min.

### P2 — `server/index.ts`: use UUID for `/api/upload` job IDs
The `/api/upload` fallback route generated `job_<timestamp>_<random>` IDs but `validateJobId` on `/api/jobs/job-status/:id` uses `isUUID()`, so the fallback flow couldn't be polled at all. Switched the fallback to `uuidv4()` for consistency.

## Not addressed here
- P2 — `server/models/user.ts:74` (email uniqueness race during signup): requires a new Firestore index collection and transactions. Architecturally significant; will confirm the approach with the user before making that change.

## Test plan
- [ ] `python -m pytest tests/ -v` — passes in CI (both env_validation and integration tests run)
- [ ] `curl` unauthenticated login 11+ times from the same IP — 11th returns 429
- [ ] Full 3-step upload flow — `/upload-url` and `/start-job` each have their own 5-slot budget
- [ ] `POST /api/upload` + `GET /api/jobs/job-status/:id` on the returned id — id validates and returns job doc