### PR TITLE
fix(01): enforce email uniqueness atomically during signup

### DIFF
--- a/frontend/server/__tests__/models/user.test.ts
+++ b/frontend/server/__tests__/models/user.test.ts
@@ -14,11 +14,17 @@ const mockLimit = jest.fn();
 const mockDoc = jest.fn();
 const mockCollection = jest.fn();
 
+// Transaction-scoped mocks used by createUser's runTransaction block
+const mockTxGet = jest.fn();
+const mockTxSet = jest.fn();
+const mockRunTransaction = jest.fn();
+
 // Mock Firestore constructor
 jest.mock('@google-cloud/firestore', () => {
   return {
     Firestore: jest.fn().mockImplementation(() => ({
       collection: mockCollection,
+      runTransaction: mockRunTransaction,
     })),
   };
 });
@@ -58,6 +64,19 @@ describe('User model', () => {
       get: mockGet,
     });
 
+    // runTransaction() invokes the callback with a transaction object that
+    // exposes tx.get / tx.set. We forward only the data argument to the
+    // top-level mockSet so existing assertions on `mockSet.mock.calls[i][0]`
+    // (which treat the first argument as the saved data) keep working for
+    // the new createUser path. Tests program mockTxGet to control the
+    // "email already exists" branch.
+    mockRunTransaction.mockImplementation(async (callback: any) => {
+      return callback({
+        get: mockTxGet,
+        set: (_ref: any, data: any) => mockSet(data),
+      });
+    });
+
     // Import user model after mocks are set up
     const userModule = await import('../../models/user');
     createUser = userModule.createUser;
@@ -74,11 +93,8 @@ describe('User model', () => {
       const email = 'test@example.com';
       const password = 'TestPassword123';
 
-      // Mock getUserByEmail to return null (email doesn't exist)
-      mockGet.mockResolvedValueOnce({
-        empty: true,
-        docs: [],
-      });
+      // Mock the in-transaction read of the email_index doc: email doesn't exist
+      mockTxGet.mockResolvedValueOnce({ exists: false });
 
       const user = await createUser(email, password);
 
@@ -90,11 +106,8 @@ describe('User model', () => {
     });
 
     it('should return user object without passwordHash', async () => {
-      // Mock getUserByEmail to return null (email doesn't exist)
-      mockGet.mockResolvedValueOnce({
-        empty: true,
-        docs: [],
-      });
+      // Mock the in-transaction read of the email_index doc: email doesn't exist
+      mockTxGet.mockResolvedValueOnce({ exists: false });
 
       const user = await createUser('test@example.com', 'password123');
 
@@ -107,15 +120,26 @@ describe('User model', () => {
     });
 
     it('should throw if email already exists', async () => {
-      // Mock email already exists
-      mockGet.mockResolvedValueOnce({
-        empty: false,
-        docs: [{ id: 'existing-id', data: () => ({ email: 'test@example.com' }) }],
-      });
+      // Mock the in-transaction read of the email_index doc: email exists
+      mockTxGet.mockResolvedValueOnce({ exists: true });
 
       await expect(createUser('test@example.com', 'password123'))
         .rejects
         .toThrow('Email already registered');
+    });
+
+    it('should write both user doc and email_index doc atomically', async () => {
+      mockTxGet.mockResolvedValueOnce({ exists: false });
+
+      await createUser('test@example.com', 'password123');
+
+      // Expect two tx.set() calls: one for the user doc, one for the email index
+      expect(mockSet).toHaveBeenCalledTimes(2);
+      const userDocData = mockSet.mock.calls[0][0] as any;
+      const emailIndexData = mockSet.mock.calls[1][0] as any;
+      expect(userDocData.email).toBe('test@example.com');
+      expect(userDocData.passwordHash).toBeDefined();
+      expect(emailIndexData.userId).toBe(userDocData.id);
     });
   });
 

--- a/frontend/server/models/user.ts
+++ b/frontend/server/models/user.ts
@@ -11,7 +11,23 @@ import crypto from 'crypto';
 // Initialize Firestore
 const firestore = new Firestore();
 const USERS_COLLECTION = 'users';
+/**
+ * Firestore collection used as a unique-email index. Document ID is the
+ * normalized email, value is `{ userId }`. Writing to this collection inside
+ * the same transaction that creates the user document gives us atomic email
+ * uniqueness: two concurrent signups for the same email cannot both commit.
+ */
+const EMAIL_INDEX_COLLECTION = 'email_index';
 const BCRYPT_ROUNDS = 12;
+
+/**
+ * Normalize an email for storage and for use as the `email_index` document
+ * key. Kept simple (lowercase + trim) so it is stable and deterministic;
+ * Firestore document IDs allow `@` and `.`, so no escaping is needed.
+ */
+function normalizeEmail(email: string): string {
+  return email.toLowerCase().trim();
+}
 
 /**
  * User interface (without passwordHash, but still contains sensitive fields
@@ -60,36 +76,49 @@ export function toPublicUser(user: User | UserInternal): PublicUser {
 }
 
 /**
- * Create a new user with hashed password
+ * Create a new user with hashed password.
+ *
+ * Email uniqueness is enforced atomically using a Firestore transaction and
+ * a dedicated `email_index` collection keyed by the normalized email. The
+ * transaction reads the email index doc and, only if it does not exist,
+ * writes both the user document and the email index doc in a single commit.
+ * Two concurrent signups for the same email therefore cannot both succeed:
+ * the second transaction will see the first write and throw.
+ *
  * @param email - User's email address
  * @param password - Plain text password (will be hashed)
  * @returns User object without passwordHash
  * @throws Error if email already exists
  */
 export async function createUser(email: string, password: string): Promise<User> {
-  // Check if email already exists
-  const existingUser = await getUserByEmail(email);
-  if (existingUser) {
-    throw new Error('Email already registered');
-  }
+  const normalizedEmail = normalizeEmail(email);
 
-  // Generate user ID and hash password
+  // Generate user ID and hash password up front (hashing is CPU-bound, keep
+  // it outside the transaction so we don't hold the transaction open).
   const userId = uuidv4();
   const passwordHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
   const verificationToken = crypto.randomBytes(32).toString('hex');
 
-  // Create user document
   const userData: UserInternal = {
     id: userId,
-    email,
+    email: normalizedEmail,
     passwordHash,
     createdAt: new Date().toISOString(),
     emailVerified: false,
     verificationToken,
   };
 
-  // Save to Firestore
-  await firestore.collection(USERS_COLLECTION).doc(userId).set(userData);
+  const userRef = firestore.collection(USERS_COLLECTION).doc(userId);
+  const emailRef = firestore.collection(EMAIL_INDEX_COLLECTION).doc(normalizedEmail);
+
+  await firestore.runTransaction(async (tx) => {
+    const existing = await tx.get(emailRef);
+    if (existing.exists) {
+      throw new Error('Email already registered');
+    }
+    tx.set(userRef, userData);
+    tx.set(emailRef, { userId, createdAt: userData.createdAt });
+  });
 
   // Return user without passwordHash
   const { passwordHash: _, ...userPublic } = userData;
@@ -104,7 +133,7 @@ export async function createUser(email: string, password: string): Promise<User>
 export async function getUserByEmail(email: string): Promise<UserInternal | null> {
   const snapshot = await firestore
     .collection(USERS_COLLECTION)
-    .where('email', '==', email)
+    .where('email', '==', normalizeEmail(email))
     .limit(1)
     .get();
 


### PR DESCRIPTION
Addresses the remaining Codex P2 on PR #12: email uniqueness race in `createUser`. Will be fast-forwarded into `feat/phase-01-security-foundation` so it appears directly in PR #12.

## Problem
`createUser` previously did `getUserByEmail` (query) → check → `collection(users).doc(uuidv4()).set(userData)`. Two concurrent signups for the same email could both pass the read check and each write a new user doc with a different UUID, leaving duplicate rows for the same email and making later `getUserByEmail` / `getUserByResetToken` lookups nondeterministic.

## Fix
Approach chosen by user: **email-keyed index collection + Firestore transaction**.

- New collection `email_index`, document ID = normalized email (`lowercase + trim`), value = `{ userId, createdAt }`.
- `createUser` now runs a `firestore.runTransaction(...)` that:
  1. Reads the `email_index` doc for the normalized email inside the transaction
  2. Throws `"Email already registered"` if it exists
  3. Otherwise `tx.set(userRef, userData)` and `tx.set(emailRef, { userId, createdAt })` in the same commit
- Because both writes commit together, two concurrent signups cannot both succeed — the second transaction sees the first write and throws.
- `getUserByEmail` also normalizes the email before the `where` query so callers that pass a non-normalized email (for example `/api/auth/request-reset`, which is not currently run through the express-validator normalizer) still find the stored user.
- Password hashing stays outside the transaction so the transaction is not held open for ~0.3 s per signup.

## Test updates
- `user.test.ts` now mocks `runTransaction` and programs `tx.get` to control the "email already exists" branch. Existing assertions of the form `mockSet.mock.calls[0][0]` keep working via a small adapter that forwards only the data argument from `tx.set(ref, data)` to the top-level `mockSet` spy.
- Added a new test that asserts both the user doc and the `email_index` doc are written in the same transaction, with `emailIndexData.userId === userDocData.id`.

## Test plan
- [ ] `npm --prefix frontend test -- user.test` — passes
- [ ] Two concurrent `POST /api/auth/signup` requests with the same email — exactly one 201, one 400 `Email already registered`
- [ ] `POST /api/auth/request-reset` with a mixed-case email for a user that signed up in lowercase — still finds the user