### PR TITLE
fix(02): stale takeover reset + Vertex re-dispatch guard (PR #13 Codex)

### DIFF
--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -315,6 +315,36 @@ def test_is_claim_stale_missing_timestamp_is_stale():
     assert _is_claim_stale(None) is True
 
 
+def _make_stale_claim_mocks(status_value, claimed_at, vertex_job_name=None):
+    """Shared fixture for try_take_over_stale_claim tests."""
+    mock_snapshot = Mock()
+    mock_snapshot.exists = True
+
+    stored = {
+        'status': status_value,
+        'claimedAt': claimed_at,
+    }
+    if vertex_job_name is not None:
+        stored['vertexJobName'] = vertex_job_name
+
+    def _snapshot_get(field, default=None):
+        return stored.get(field, default)
+
+    mock_snapshot.get = Mock(side_effect=_snapshot_get)
+
+    mock_ref = Mock()
+    mock_ref.id = f"job-{status_value}"
+    mock_ref.get = Mock(return_value=mock_snapshot)
+
+    mock_transaction = Mock()
+    mock_transaction.update = Mock()
+
+    mock_db = Mock()
+    mock_db.transaction = Mock(return_value=mock_transaction)
+
+    return mock_ref, mock_transaction, mock_db
+
+
 def test_try_take_over_stale_claim_wins_when_claim_is_old():
     """
     try_take_over_stale_claim() refreshes `claimedAt` via a Firestore
@@ -328,24 +358,9 @@ def test_try_take_over_stale_claim_wins_when_claim_is_old():
         seconds=JOB_CLAIM_STALE_SECONDS + 60
     )
 
-    mock_snapshot = Mock()
-    mock_snapshot.exists = True
-    def _snapshot_get(field, default=None):
-        return {
-            'status': JobStatus.PROCESSING.value,
-            'claimedAt': old_claim,
-        }.get(field, default)
-    mock_snapshot.get = Mock(side_effect=_snapshot_get)
-
-    mock_ref = Mock()
-    mock_ref.id = "job-stale"
-    mock_ref.get = Mock(return_value=mock_snapshot)
-
-    mock_transaction = Mock()
-    mock_transaction.update = Mock()
-
-    mock_db = Mock()
-    mock_db.transaction = Mock(return_value=mock_transaction)
+    mock_ref, mock_transaction, mock_db = _make_stale_claim_mocks(
+        JobStatus.PROCESSING.value, old_claim
+    )
 
     with patch('worker.db', mock_db), \
          patch('worker.firestore') as mock_firestore:
@@ -359,9 +374,83 @@ def test_try_take_over_stale_claim_wins_when_claim_is_old():
 
     assert result is True
     mock_transaction.update.assert_called_once()
-    # The update payload must refresh claimedAt.
     payload = mock_transaction.update.call_args[0][1]
     assert 'claimedAt' in payload
+    # Codex P1 followup: takeover must ALSO reset status to PROCESSING
+    # so the downstream pipeline can restart from scratch instead of
+    # hitting an invalid "training -> training" transition.
+    assert payload['status'] == JobStatus.PROCESSING.value
+
+
+def test_try_take_over_stale_claim_resets_training_to_processing():
+    """
+    Codex P1 r(stale-takeover-from-training): if the crashed worker had
+    already transitioned the job past PROCESSING (e.g. to TRAINING), the
+    takeover must still restart the pipeline from PROCESSING so the
+    normal PROCESSING -> TRAINING -> SCORING -> COMPLETE flow works
+    without hitting an invalid "training -> training" transition.
+    """
+    import datetime as _dt
+    from worker import try_take_over_stale_claim, JobStatus, JOB_CLAIM_STALE_SECONDS
+
+    old_claim = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(
+        seconds=JOB_CLAIM_STALE_SECONDS + 60
+    )
+
+    for stuck_state in (JobStatus.TRAINING.value, JobStatus.SCORING.value):
+        mock_ref, mock_transaction, mock_db = _make_stale_claim_mocks(
+            stuck_state, old_claim
+        )
+
+        with patch('worker.db', mock_db), \
+             patch('worker.firestore') as mock_firestore:
+            def transactional_decorator(func):
+                def wrapper(transaction, ref):
+                    return func(transaction, ref)
+                return wrapper
+            mock_firestore.transactional = transactional_decorator
+
+            result = try_take_over_stale_claim(mock_ref)
+
+        assert result is True, f"takeover should succeed from {stuck_state}"
+        payload = mock_transaction.update.call_args[0][1]
+        assert payload['status'] == JobStatus.PROCESSING.value, (
+            f"takeover from {stuck_state} must reset status to processing"
+        )
+
+
+def test_try_take_over_stale_claim_refuses_when_vertex_dispatched():
+    """
+    Codex P1 r(vertex-stale-redispatch): if the job doc already carries
+    a `vertexJobName`, Vertex owns the training run. Re-taking over
+    would resubmit a duplicate (billable) Vertex job. Even if the
+    stored `claimedAt` looks stale, takeover must refuse.
+    """
+    import datetime as _dt
+    from worker import try_take_over_stale_claim, JobStatus, JOB_CLAIM_STALE_SECONDS
+
+    old_claim = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(
+        seconds=JOB_CLAIM_STALE_SECONDS + 60
+    )
+
+    mock_ref, mock_transaction, mock_db = _make_stale_claim_mocks(
+        JobStatus.PROCESSING.value,
+        old_claim,
+        vertex_job_name="projects/x/locations/us-central1/customJobs/123",
+    )
+
+    with patch('worker.db', mock_db), \
+         patch('worker.firestore') as mock_firestore:
+        def transactional_decorator(func):
+            def wrapper(transaction, ref):
+                return func(transaction, ref)
+            return wrapper
+        mock_firestore.transactional = transactional_decorator
+
+        result = try_take_over_stale_claim(mock_ref)
+
+    assert result is False
+    mock_transaction.update.assert_not_called()
 
 
 def test_try_take_over_stale_claim_rejects_fresh_claim():

--- a/worker.py
+++ b/worker.py
@@ -422,12 +422,25 @@ def try_take_over_stale_claim(job_ref):
     us an escape hatch: a duplicate delivery that finds the claim
     abandoned (no heartbeat refresh for more than JOB_CLAIM_STALE_SECONDS)
     transactionally bumps `claimedAt` to now and returns True, letting
-    the caller continue processing from wherever the dead worker left off.
+    the caller resume processing.
 
-    Only refreshes `claimedAt`. Does NOT change `status`, because the
-    existing state machine already allows transitions OUT of the
-    in-progress buckets (PROCESSING -> TRAINING, TRAINING -> SCORING,
-    etc.), and the caller can resume from the current state.
+    Codex P1 (followup, r(stale-takeover-from-training)): the takeover
+    also *resets* the status to PROCESSING, even if the current state
+    is TRAINING or SCORING. Without that reset, the caller's normal
+    pipeline would try a PROCESSING -> TRAINING transition and hit an
+    "Invalid transition: training -> training" (or scoring -> training)
+    ValueError, which the outer exception handler would then mark as
+    ERROR. Crash recovery from TRAINING or SCORING would deterministically
+    fail instead of restarting the pipeline. Resetting to PROCESSING
+    means we redo the work (download, train, score) from scratch - that
+    is the safe choice because we have no way to know how far the dead
+    worker actually got before it crashed.
+
+    Codex P1 (followup, r(vertex-stale-redispatch)): suppress takeover
+    when the job doc carries a `vertexJobName`, because that indicates
+    a Vertex training job has already been successfully submitted and
+    Vertex itself (not this worker) owns the work. Re-taking it over
+    would re-submit the same Vertex training run and double-bill.
 
     The refresh happens inside a Firestore transaction, so two workers
     that both see a stale claim cannot both take over: one wins the
@@ -436,8 +449,8 @@ def try_take_over_stale_claim(job_ref):
 
     Returns:
         bool: True if the claim was successfully taken over, False if
-        the claim is still fresh or the doc is not in a recoverable
-        in-progress state.
+        the claim is still fresh, the doc is not in a recoverable
+        in-progress state, or a Vertex job is already dispatched.
     """
     in_progress_states = {
         JobStatus.PROCESSING.value,
@@ -453,12 +466,26 @@ def try_take_over_stale_claim(job_ref):
         current_status = snapshot.get('status')
         if current_status not in in_progress_states:
             return False
+        # Vertex guard: if the dispatcher already handed the job off to
+        # Vertex, it is Vertex's responsibility to run and update status.
+        # Re-taking over would re-submit the same training run.
+        if snapshot.get('vertexJobName'):
+            return False
         claimed_at = snapshot.get('claimedAt')
         if not _is_claim_stale(claimed_at):
             return False
         transaction.update(
             ref,
-            {'claimedAt': datetime.now(timezone.utc)},
+            {
+                # Reset status back to PROCESSING so the calling pipeline
+                # can restart from the beginning regardless of which
+                # in-progress sub-state (processing/training/scoring) the
+                # dead worker crashed in. This is a direct write that
+                # bypasses the normal state machine transition check,
+                # which is the whole point of this escape hatch.
+                'status': JobStatus.PROCESSING.value,
+                'claimedAt': datetime.now(timezone.utc),
+            },
         )
         return True
 
@@ -467,7 +494,8 @@ def try_take_over_stale_claim(job_ref):
     if took_over:
         logger.warning(
             f"Stale claim taken over for job {getattr(job_ref, 'id', '?')} "
-            f"(previous worker appears to have crashed)"
+            f"(previous worker appears to have crashed); status reset to "
+            f"PROCESSING to restart the pipeline"
         )
     return took_over
 
@@ -1063,6 +1091,53 @@ def process_upload_vertex(job_id, bucket_name, file_path, message):
         )
 
         logger.info("Job submitted to Vertex AI.")
+
+        # Codex P1 r(vertex-stale-redispatch): the dispatcher is about
+        # to return, but the Vertex training job it just submitted will
+        # keep running for many minutes. If we left the job doc as-is,
+        # the `claimedAt` heartbeat would stop and after 3 minutes a
+        # duplicate Pub/Sub delivery could trigger stale-claim takeover
+        # and re-submit the same Vertex training run -> duplicate billing
+        # and duplicate writes to the same job doc.
+        #
+        # Mitigations, in order:
+        #
+        # 1. Stop the AckExtender heartbeat BEFORE writing our suppressor
+        #    values, so the heartbeat timer cannot race with us and
+        #    overwrite our far-future claimedAt.
+        #
+        # 2. Record the Vertex job resource name on the job doc. That
+        #    field gates try_take_over_stale_claim: if `vertexJobName`
+        #    is set, the takeover function treats the job as externally
+        #    owned and refuses to re-dispatch.
+        #
+        # 3. As a defense-in-depth belt to the vertexJobName suspenders,
+        #    also set `claimedAt` to a timestamp far in the future
+        #    (100 years) so even if some future reader ignores
+        #    `vertexJobName`, _is_claim_stale still reports "fresh" and
+        #    the takeover path still rejects the duplicate delivery.
+        extender.stop()
+        try:
+            vertex_job_name = getattr(job, 'resource_name', None) or \
+                getattr(job, 'name', None) or \
+                f"vertex-dispatched-{job_id}"
+            far_future_claim = datetime.now(timezone.utc) + timedelta(
+                days=365 * 100
+            )
+            job_ref.update({
+                'vertexJobName': vertex_job_name,
+                'claimedAt': far_future_claim,
+            })
+        except Exception as meta_err:
+            # If we can't persist the suppressor fields, the worst case
+            # is that a duplicate delivery will trigger a second Vertex
+            # dispatch after JOB_CLAIM_STALE_SECONDS. Log so the operator
+            # can see the gap and continue - the job is already running
+            # on Vertex, which is the important invariant.
+            logger.warning(
+                f"Failed to persist Vertex takeover suppressor for "
+                f"job {job_id}: {meta_err}"
+            )
 
     except JobDocumentNotReadyError:
         # Never swallow: callback() must nack for Pub/Sub redelivery.


### PR DESCRIPTION
Two Codex P1 follow-ups on the stale-claim takeover mechanism from the previous PR:

**1. `r(stale-takeover-from-training)` — line 859:** `try_take_over_stale_claim()` only refreshed `claimedAt`. If the crashed worker had already moved the job past `PROCESSING` into `TRAINING` or `SCORING`, the caller's pipeline would then try a `PROCESSING → TRAINING` transition and hit an invalid-transition `ValueError` (`training → training` or `scoring → training`). The outer exception handler would mark the job `ERROR`, so crash recovery only worked for stale `processing` claims and failed deterministically for crashes during training or scoring.

**Fix:** the takeover transaction now also resets `status` back to `PROCESSING` as part of the same atomic update. This is a direct write that bypasses the state-machine transition check, which is the whole point of the escape hatch. The caller then restarts from scratch (download → validate → load → train → score), which is the safe choice because we have no way to know how far the dead worker actually got before it crashed.

**2. `r(vertex-stale-redispatch)` — line 1018:** `process_upload_vertex` is a thin dispatcher: it calls `job.run(sync=False)` and returns. The `AckExtender` heartbeat stops within a minute of return, but the Vertex training job keeps running for many more minutes. Within `JOB_CLAIM_STALE_SECONDS` (3 min) the `claimedAt` heartbeat goes stale, and any duplicate Pub/Sub delivery would then hit `try_take_over_stale_claim`, reclaim the job, and submit a **second** (billable) Vertex training job against the same `jobId`.

**Fix:** layered mitigation after `job.run()` returns:
1. Stop the `AckExtender` heartbeat **before** writing the suppressor fields, so the heartbeat timer cannot race with us.
2. Persist `vertexJobName` (Vertex resource name / display name) on the job doc. `try_take_over_stale_claim` checks for this field and short-circuits to `return False`, treating the job as externally owned by Vertex.
3. Defense-in-depth: also bump `claimedAt` to `now + 100 years` so `_is_claim_stale` reports "fresh" even if a future reader ignores the `vertexJobName` gate.

**Tests:** `tests/test_idempotency.py`
- `test_try_take_over_stale_claim_wins_when_claim_is_old` now also asserts the payload resets `status` to `processing`.
- New `test_try_take_over_stale_claim_resets_training_to_processing` covers takeover from both `TRAINING` and `SCORING` states.
- New `test_try_take_over_stale_claim_refuses_when_vertex_dispatched` covers the `vertexJobName` short-circuit.