### PR TITLE
fix(02): Vertex suppressor robustness + retry file binding (PR #13 Codex)

### DIFF
--- a/frontend/server/routes/jobs.ts
+++ b/frontend/server/routes/jobs.ts
@@ -154,12 +154,20 @@ router.post("/start-job", requireAuth, uploadLimiter, validateStartJob, async (r
     // re-publish. The worker-side dedup (check_idempotency and
     // mark_message_processed in worker.py) makes a duplicate publish
     // on retry harmless.
+    // Codex P2 r(retry-file-binding): persist `gcsFileName` on the
+    // claimed job doc and require same-user retries to present the
+    // EXACT same file path. Without this check, a client that retried
+    // /start-job with the same jobId but a different gcsFileName
+    // (accident, bug, or malice) would overwrite the logical meaning
+    // of the claimed job and cause two different files to race under
+    // one jobId, producing nondeterministic results.
     let claimedExistingDoc = false;
     try {
       await firestore.collection("jobs").doc(jobId).create({
         status: "queued", // Initial state (matches worker JobStatus.QUEUED)
         createdAt: new Date(),
         userId,
+        gcsFileName, // Pin the retry to this exact object path.
       });
     } catch (createErr: any) {
       // Firestore raises code 6 (ALREADY_EXISTS) when create() hits an
@@ -169,22 +177,23 @@ router.post("/start-job", requireAuth, uploadLimiter, validateStartJob, async (r
       }
 
       // Same-user retry recovery: if the existing doc is owned by this
-      // caller and still in the initial "queued" state (no worker has
-      // picked it up yet), treat the request as a publish retry and
-      // reuse the claim. Any other combination (different owner, or a
-      // status past "queued") is a real collision / replay attempt and
-      // gets the 409.
+      // caller AND is still in the initial "queued" state AND targets
+      // the exact same uploaded object, treat the request as a publish
+      // retry and reuse the claim. Any other combination is a real
+      // collision / replay attempt and gets the 409.
       const existingDoc = await firestore.collection("jobs").doc(jobId).get();
       const existing = existingDoc.exists ? existingDoc.data() : undefined;
       if (
         existing &&
         existing.userId === userId &&
-        existing.status === "queued"
+        existing.status === "queued" &&
+        existing.gcsFileName === gcsFileName
       ) {
         claimedExistingDoc = true;
         logger.info("start-job: reusing pre-existing queued doc for retry", {
           jobId,
           userId,
+          gcsFileName,
         });
       } else {
         logger.warn("start-job rejected: jobId already claimed", {
@@ -192,6 +201,13 @@ router.post("/start-job", requireAuth, uploadLimiter, validateStartJob, async (r
           userId,
           existingOwner: existing?.userId,
           existingStatus: existing?.status,
+          // Log the file mismatch so operators can see it in the audit
+          // trail. Do NOT log the existing.gcsFileName value if it
+          // belongs to a different user (we already blocked that
+          // above), but here we know the owner matched and only the
+          // file path differed, which is useful forensic data.
+          existingGcsFileName: existing?.gcsFileName,
+          requestedGcsFileName: gcsFileName,
         });
         return res.status(409).json({ error: "Job ID already exists" });
       }

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -419,6 +419,117 @@ def test_try_take_over_stale_claim_resets_training_to_processing():
         )
 
 
+def test_try_take_over_stale_claim_refuses_vertex_mode_short_window():
+    """
+    Codex P1 r(suppressor-write-failure): a job tagged `mode: "vertex"`
+    must NOT be reclaimed after the 3-minute local stale window, because
+    the Vertex training run itself routinely takes much longer than that.
+    A claimedAt just 10 minutes old is well past the local threshold but
+    comfortably inside the Vertex threshold, and takeover should refuse.
+    """
+    import datetime as _dt
+    from worker import try_take_over_stale_claim, JobStatus, JOB_CLAIM_STALE_SECONDS
+
+    ten_minutes_old = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(minutes=10)
+    assert (
+        _dt.datetime.now(_dt.timezone.utc) - ten_minutes_old
+    ).total_seconds() > JOB_CLAIM_STALE_SECONDS, (
+        "precondition: 10 minutes should be past the local stale threshold"
+    )
+
+    # Same fixture helper, but with mode=vertex in the stored doc.
+    mock_snapshot = Mock()
+    mock_snapshot.exists = True
+    stored = {
+        'status': JobStatus.PROCESSING.value,
+        'claimedAt': ten_minutes_old,
+        'mode': 'vertex',
+    }
+    mock_snapshot.get = Mock(
+        side_effect=lambda field, default=None: stored.get(field, default)
+    )
+
+    mock_ref = Mock()
+    mock_ref.id = "job-vertex-10min"
+    mock_ref.get = Mock(return_value=mock_snapshot)
+
+    mock_transaction = Mock()
+    mock_transaction.update = Mock()
+
+    mock_db = Mock()
+    mock_db.transaction = Mock(return_value=mock_transaction)
+
+    with patch('worker.db', mock_db), \
+         patch('worker.firestore') as mock_firestore:
+        def transactional_decorator(func):
+            def wrapper(transaction, ref):
+                return func(transaction, ref)
+            return wrapper
+        mock_firestore.transactional = transactional_decorator
+
+        result = try_take_over_stale_claim(mock_ref)
+
+    assert result is False, (
+        "mode=vertex jobs must not be reclaimed at the local stale "
+        "threshold, otherwise a post-dispatch metadata-write failure "
+        "would allow a duplicate Vertex training submission"
+    )
+    mock_transaction.update.assert_not_called()
+
+
+def test_try_take_over_stale_claim_reclaims_vertex_after_long_window():
+    """
+    Conversely, a `mode: "vertex"` job really is recoverable once it
+    exceeds the Vertex stale threshold (4 hours). This proves the
+    takeover path is still reachable for a truly crashed Vertex
+    dispatcher, just with a much more conservative window.
+    """
+    import datetime as _dt
+    from worker import (
+        try_take_over_stale_claim,
+        JobStatus,
+        JOB_CLAIM_STALE_SECONDS_VERTEX,
+    )
+
+    very_old = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(
+        seconds=JOB_CLAIM_STALE_SECONDS_VERTEX + 60
+    )
+
+    mock_snapshot = Mock()
+    mock_snapshot.exists = True
+    stored = {
+        'status': JobStatus.PROCESSING.value,
+        'claimedAt': very_old,
+        'mode': 'vertex',
+    }
+    mock_snapshot.get = Mock(
+        side_effect=lambda field, default=None: stored.get(field, default)
+    )
+
+    mock_ref = Mock()
+    mock_ref.id = "job-vertex-verystale"
+    mock_ref.get = Mock(return_value=mock_snapshot)
+
+    mock_transaction = Mock()
+    mock_transaction.update = Mock()
+
+    mock_db = Mock()
+    mock_db.transaction = Mock(return_value=mock_transaction)
+
+    with patch('worker.db', mock_db), \
+         patch('worker.firestore') as mock_firestore:
+        def transactional_decorator(func):
+            def wrapper(transaction, ref):
+                return func(transaction, ref)
+            return wrapper
+        mock_firestore.transactional = transactional_decorator
+
+        result = try_take_over_stale_claim(mock_ref)
+
+    assert result is True
+    mock_transaction.update.assert_called_once()
+
+
 def test_try_take_over_stale_claim_refuses_when_vertex_dispatched():
     """
     Codex P1 r(vertex-stale-redispatch): if the job doc already carries

--- a/worker.py
+++ b/worker.py
@@ -73,6 +73,20 @@ IDEMPOTENCY_MARKER_TTL_DAYS = 7
 JOB_CLAIM_HEARTBEAT_INTERVAL_SECONDS = 60
 JOB_CLAIM_STALE_SECONDS = JOB_CLAIM_HEARTBEAT_INTERVAL_SECONDS * 3
 
+# Vertex mode stale threshold. The Vertex dispatcher is a short-lived
+# fire-and-forget call (job.run(sync=False) returns in seconds) and
+# then the worker stops heartbeating because there's nothing locally
+# to keep alive. The actual Vertex training job runs on the Vertex
+# side for potentially 30+ minutes. Using the local 3-minute threshold
+# would let a duplicate Pub/Sub delivery reclaim the doc after a few
+# minutes and submit a SECOND billable Vertex training job for the
+# same logical jobId. Use a much wider window (4 hours) so stale
+# takeover only fires if the Vertex job has been running for an
+# unreasonable amount of time; the post-dispatch "far future
+# claimedAt" write is still an additional defense-in-depth belt on
+# top of this.
+JOB_CLAIM_STALE_SECONDS_VERTEX = 4 * 60 * 60
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -388,26 +402,38 @@ def update_job_status(transaction, job_ref, new_status, additional_fields=None):
     logger.info(f"Job {job_ref.id} status: {current_status} -> {new_status}")
 
 
-def _is_claim_stale(claimed_at, now=None):
+def _is_claim_stale(claimed_at, now=None, threshold_seconds=None):
     """
     Decide whether a job's `claimedAt` timestamp is stale (older than
-    JOB_CLAIM_STALE_SECONDS), meaning the claiming worker's heartbeat has
+    `threshold_seconds`), meaning the claiming worker's heartbeat has
     gone silent long enough that we should treat the claim as abandoned.
 
     Accepts timezone-aware or naive datetimes and tolerates `None`
     (missing field) by treating it as stale so legacy jobs written
     before this field existed can still be recovered.
+
+    Args:
+        claimed_at: The stored claimedAt timestamp (or None).
+        now: Current time (defaults to datetime.now(utc)). Injectable
+            for testing.
+        threshold_seconds: The staleness threshold. Defaults to the
+            local-mode JOB_CLAIM_STALE_SECONDS. Callers processing a
+            Vertex job should pass JOB_CLAIM_STALE_SECONDS_VERTEX
+            instead because the dispatcher stops heartbeating long
+            before the actual Vertex training run finishes.
     """
     if claimed_at is None:
         return True
     if now is None:
         now = datetime.now(timezone.utc)
+    if threshold_seconds is None:
+        threshold_seconds = JOB_CLAIM_STALE_SECONDS
     # Firestore returns timezone-aware datetimes; be defensive if we
     # see a naive value (tests, legacy data) by assuming UTC.
     if claimed_at.tzinfo is None:
         claimed_at = claimed_at.replace(tzinfo=timezone.utc)
     age = (now - claimed_at).total_seconds()
-    return age > JOB_CLAIM_STALE_SECONDS
+    return age > threshold_seconds
 
 
 def try_take_over_stale_claim(job_ref):
@@ -420,9 +446,9 @@ def try_take_over_stale_claim(job_ref):
     doc in an in-progress state and a naive implementation would nack
     forever (infinite redelivery loop, stuck job). This function gives
     us an escape hatch: a duplicate delivery that finds the claim
-    abandoned (no heartbeat refresh for more than JOB_CLAIM_STALE_SECONDS)
-    transactionally bumps `claimedAt` to now and returns True, letting
-    the caller resume processing.
+    abandoned (no heartbeat refresh for more than the mode-specific
+    stale threshold) transactionally bumps `claimedAt` to now and
+    returns True, letting the caller resume processing.
 
     Codex P1 (followup, r(stale-takeover-from-training)): the takeover
     also *resets* the status to PROCESSING, even if the current state
@@ -441,6 +467,16 @@ def try_take_over_stale_claim(job_ref):
     a Vertex training job has already been successfully submitted and
     Vertex itself (not this worker) owns the work. Re-taking it over
     would re-submit the same Vertex training run and double-bill.
+
+    Codex P1 (followup, r(suppressor-write-failure)): the load-bearing
+    guard against duplicate Vertex dispatch is no longer *only* the
+    post-dispatch `vertexJobName` write. Jobs tagged with
+    `mode: "vertex"` in their initial claim (see process_upload_vertex
+    below) use a much wider stale threshold
+    (JOB_CLAIM_STALE_SECONDS_VERTEX, 4 hours) so that even if the
+    post-dispatch metadata write fails, the stale-claim takeover path
+    will not reclaim the job for hours, well after any normal Vertex
+    run would have finished.
 
     The refresh happens inside a Firestore transaction, so two workers
     that both see a stale claim cannot both take over: one wins the
@@ -471,8 +507,17 @@ def try_take_over_stale_claim(job_ref):
         # Re-taking over would re-submit the same training run.
         if snapshot.get('vertexJobName'):
             return False
+        # Mode-aware stale threshold. Vertex jobs use a much wider
+        # window because the dispatcher stops heartbeating as soon as
+        # job.run() returns, and the Vertex training itself can take
+        # tens of minutes to hours to complete.
+        mode = snapshot.get('mode')
+        if mode == 'vertex':
+            threshold = JOB_CLAIM_STALE_SECONDS_VERTEX
+        else:
+            threshold = JOB_CLAIM_STALE_SECONDS
         claimed_at = snapshot.get('claimedAt')
-        if not _is_claim_stale(claimed_at):
+        if not _is_claim_stale(claimed_at, threshold_seconds=threshold):
             return False
         transaction.update(
             ref,
@@ -1019,7 +1064,19 @@ def process_upload_vertex(job_id, bucket_name, file_path, message):
                 transaction,
                 job_ref,
                 JobStatus.PROCESSING,
-                additional_fields={'claimedAt': datetime.now(timezone.utc)},
+                # Codex P1 r(suppressor-write-failure): tag the job as
+                # `mode: "vertex"` in the same transaction that claims
+                # it. try_take_over_stale_claim uses this tag to pick a
+                # much wider stale threshold (4 hours instead of 3
+                # minutes), so even if the post-dispatch suppressor
+                # write (vertexJobName / far-future claimedAt) later
+                # fails, stale takeover still cannot fire during the
+                # expected Vertex run window and we cannot
+                # double-dispatch.
+                additional_fields={
+                    'claimedAt': datetime.now(timezone.utc),
+                    'mode': 'vertex',
+                },
             )
         except ValueError as e:
             if "not found" in str(e):


### PR DESCRIPTION
Two Codex follow-ups on PR #13:

**Codex P1 `r(suppressor-write-failure)` — `worker.py:1168`**
`process_upload_vertex` was counting on a post-dispatch best-effort write of `vertexJobName` + far-future `claimedAt` to suppress stale-claim takeover during the (potentially hours-long) Vertex training window. If that write failed, `callback()` still acked the message, leaving the job in plain `processing` with an old heartbeat. A later duplicate delivery could then reclaim the doc after the 3-minute local window and submit a **second** billable Vertex training run.

**Fix:** move the load-bearing suppression into the **initial** claim transaction. `process_upload_vertex` now also writes `mode: "vertex"` alongside the `queued → processing` transition, and `try_take_over_stale_claim` / `_is_claim_stale` pick a much wider `JOB_CLAIM_STALE_SECONDS_VERTEX` (4 hours) for jobs tagged that way. Even if the post-dispatch metadata write still fails, stale takeover cannot fire during the expected Vertex run window and we cannot double-dispatch. The 4-hour threshold is still short enough to recover a truly crashed Vertex dispatcher (the rare case where `job.run()` never actually submitted).

**Codex P2 `r(retry-file-binding)` — `frontend/server/routes/jobs.ts:183`**
The same-user retry branch on `/start-job` accepted any request for a `jobId` whose existing doc was owned by the caller and still `queued`, but never checked that the retry targeted the same uploaded object. A client retrying with the same `jobId` but a different `gcsFileName` (accident / bug / replay) would have the retry accepted and re-published, so two different files could race under one logical `jobId`.

**Fix:** persist `gcsFileName` on the claimed job document, and require the retry branch's existing-doc checks to match on `gcsFileName` in addition to owner and status. A mismatch is treated as a real collision and returns 409. The operator log entry captures both the stored and requested values for forensics.

**Tests:**
- `test_try_take_over_stale_claim_refuses_vertex_mode_short_window`: a 10-minute old `mode=vertex` claim must **not** be reclaimed.
- `test_try_take_over_stale_claim_reclaims_vertex_after_long_window`: once the `mode=vertex` claim exceeds the 4-hour threshold, takeover still works.

All 40 tests in the affected modules pass locally.