### PR TITLE
fix(02): ack duplicate deliveries for already-dispatched Vertex jobs (PR #13)

### DIFF
--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -248,6 +248,41 @@ def test_duplicate_delivery_while_job_in_progress_nacks_without_marking():
     mock_mark.assert_not_called()
 
 
+def test_duplicate_delivery_for_vertex_dispatched_job_acks_cleanly():
+    """
+    Codex P2 r(vertex-dispatched-ack): a duplicate delivery for a job
+    whose doc already carries `vertexJobName` must be ack-dropped, not
+    nacked. Nacking would create an infinite Pub/Sub redelivery loop
+    against a job that Vertex is already running, burning worker
+    capacity with no path to progress.
+
+    We simulate this by having process_upload_local / _vertex return
+    normally (as they will after the new "vertexJobName short-circuit"
+    branch in the invalid-transition handler). callback() should then
+    ack + mark the message as processed, not nack.
+    """
+    from worker import callback
+
+    message = Mock()
+    message.data = json.dumps({
+        "jobId": "job-vertex-dup",
+        "bucket": "test-bucket",
+        "file": "test.csv"
+    }).encode("utf-8")
+    message.message_id = "msg-vertex-dup"
+    message.ack = Mock()
+    message.nack = Mock()
+
+    with patch('worker.check_idempotency', return_value=False), \
+         patch('worker.process_upload_local', return_value=None), \
+         patch('worker.mark_message_processed') as mock_mark:
+        callback(message)
+
+    message.ack.assert_called_once()
+    message.nack.assert_not_called()
+    mock_mark.assert_called_once()
+
+
 def test_job_document_not_ready_nacks_without_marking():
     """
     Codex P1 (r3053739500): if /start-job hasn't written the Firestore

--- a/worker.py
+++ b/worker.py
@@ -865,6 +865,24 @@ def process_upload_local(job_id, bucket_name, file_path, message):
                 )
                 return
             if current_status in in_progress_states:
+                # Codex P2 r(vertex-dispatched-ack): if the doc carries
+                # `vertexJobName`, the previous run has already handed
+                # the job off to Vertex and Vertex owns it. A duplicate
+                # /start-job republish (or Pub/Sub redelivery) should
+                # NOT bounce around in an infinite
+                # JobInProgressError -> nack -> redeliver loop; there
+                # is no local work to do here, Vertex itself will
+                # update the job status. Treat this as a clean skip
+                # (return) so callback() acks and marks the duplicate
+                # message as processed.
+                if snapshot.get('vertexJobName'):
+                    logger.info(
+                        f"Job {job_id} already dispatched to Vertex "
+                        f"(vertexJobName set), skipping duplicate local "
+                        f"delivery"
+                    )
+                    return
+
                 # Stale-takeover path: if the previous worker's heartbeat
                 # has gone silent long enough that we consider the claim
                 # abandoned, reclaim it and fall through to continue
@@ -1171,6 +1189,24 @@ def process_upload_vertex(job_id, bucket_name, file_path, message):
                 )
                 return
             if current_status in in_progress_states:
+                # Codex P2 r(vertex-dispatched-ack): if the doc already
+                # carries `vertexJobName`, a previous delivery already
+                # successfully submitted the job to Vertex. Nothing
+                # more for the dispatcher to do here - Vertex owns the
+                # training run now. Treat the duplicate as a clean
+                # skip (return) so callback() acks and marks it; the
+                # alternative (raise JobInProgressError -> nack -> Pub/Sub
+                # redelivers) would create an infinite redelivery loop
+                # that burns worker capacity until Vertex finishes and
+                # updates status on its own.
+                if snapshot.get('vertexJobName'):
+                    logger.info(
+                        f"Job {job_id} already dispatched to Vertex "
+                        f"(vertexJobName set), skipping duplicate Vertex "
+                        f"dispatch"
+                    )
+                    return
+
                 # Try stale-claim takeover before giving up. For Vertex
                 # mode the dispatcher's active time is normally seconds
                 # (just long enough to submit the job.run call), so a
@@ -1179,12 +1215,8 @@ def process_upload_vertex(job_id, bucket_name, file_path, message):
                 #
                 # Pass mode="vertex" so the takeover transaction stamps
                 # that tag on the recovered doc atomically. Otherwise a
-                # legacy / untagged recovered doc would use the short
-                # local stale threshold for any subsequent duplicate
-                # deliveries, and the post-dispatch suppressor write
-                # window could still race a duplicate delivery into
-                # submitting a second Vertex training run
-                # (Codex P2 r(takeover-mode-tag)).
+                # legacy / untagged recovered doc would lose the mode
+                # tag for any subsequent duplicate deliveries.
                 if try_take_over_stale_claim(job_ref, mode='vertex'):
                     logger.info(
                         f"Resuming Vertex dispatch for job {job_id} "


### PR DESCRIPTION
Addresses Codex P2 `r(vertex-dispatched-ack)` on `worker.py` line 1200.

**The bug:** when a duplicate Pub/Sub delivery arrived for a job whose doc already carried `vertexJobName` (Vertex was already running the training), the invalid-transition handler would:

1. Read state → in-progress
2. Call `try_take_over_stale_claim()` which refused because `vertexJobName` was set
3. Raise `JobInProgressError`
4. `callback()` nacked the message
5. Pub/Sub redelivered → infinite loop

**Fix:** add an explicit `vertexJobName` short-circuit in the in-progress branch of the invalid-transition handler (in **both** `process_upload_local` and `process_upload_vertex`). If `vertexJobName` is set, Vertex owns the training run, there is no local work to do, and the duplicate delivery is ack-dropped via a clean `return` so `callback()` marks it as processed. Vertex itself will update the job status when the training run finishes.

**Tests:** new `test_duplicate_delivery_for_vertex_dispatched_job_acks_cleanly` asserts that `callback()` with a `process_upload_local` that returns cleanly (i.e. the new vertex-dispatched short-circuit path) acks + marks the message instead of nacking.

All 47 tests in the affected modules pass locally.