### PR TITLE
fix: repair broken test suite (conftest GCP mocks + 3 test bugs)

### DIFF
--- a/evaluate/outliers.py
+++ b/evaluate/outliers.py
@@ -114,14 +114,14 @@ def compute_per_column_contributions(
         ]
     else:
         contributions = [
-            (column_names[i], (per_attr_losses[i] / total_loss) * 100.0)
+            (column_names[i], float((per_attr_losses[i] / total_loss) * 100.0))
             for i in range(len(per_attr_losses))
         ]
 
     # Normalize to exactly 100% (address potential floating-point rounding issues)
     total_pct = sum(pct for _, pct in contributions)
     contributions = [
-        (col, (pct / total_pct) * 100.0)
+        (col, float((pct / total_pct) * 100.0))
         for col, pct in contributions
     ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,25 +52,66 @@ def _install_gcp_client_stubs() -> None:
     patch `worker.db` directly (e.g. `with patch.object(worker, "db", ...)`),
     which still works because the MagicMock we leave behind has MagicMock
     attribute access by default.
-    """
-    try:
-        from google.cloud import firestore as _firestore
-        from google.cloud import pubsub_v1 as _pubsub_v1
-        from google.cloud import storage as _storage
-    except ImportError:
-        # Google Cloud libraries not installed at all - nothing to patch,
-        # tests that depend on them will fail naturally with a clearer
-        # error message.
-        return
 
-    _firestore.Client = MagicMock(return_value=MagicMock(name="FirestoreClient"))
-    _pubsub_v1.SubscriberClient = MagicMock(
+    Instead of importing the real libraries (which can crash if the
+    cryptography C extension is broken — e.g. pyo3_runtime.PanicException),
+    we inject lightweight mock modules directly into sys.modules. This
+    avoids the entire google-auth → cryptography import chain.
+    """
+    # Build mock modules for each GCP client library.
+    _mock_firestore = MagicMock(name="mock_firestore_module")
+    _mock_firestore.Client = MagicMock(return_value=MagicMock(name="FirestoreClient"))
+
+    _mock_pubsub = MagicMock(name="mock_pubsub_v1_module")
+    _mock_pubsub.SubscriberClient = MagicMock(
         return_value=MagicMock(name="SubscriberClient")
     )
-    _pubsub_v1.PublisherClient = MagicMock(
+    _mock_pubsub.PublisherClient = MagicMock(
         return_value=MagicMock(name="PublisherClient")
     )
-    _storage.Client = MagicMock(return_value=MagicMock(name="StorageClient"))
+
+    _mock_storage = MagicMock(name="mock_storage_module")
+    _mock_storage.Client = MagicMock(return_value=MagicMock(name="StorageClient"))
+
+    # Make firestore.transactional a pass-through so decorated functions
+    # (e.g. update_job_status) keep their real implementation.
+    _mock_firestore.transactional = lambda fn: fn
+
+    # Inject mock leaf modules into sys.modules for the three GCP client
+    # libraries.  We do NOT touch the "google" or "google.cloud" namespace
+    # packages — they are shared with google-protobuf, grpcio, and
+    # TensorFlow and must keep their real __path__ so sub-package
+    # resolution continues to work.
+    sys.modules["google.cloud.firestore"] = _mock_firestore
+    sys.modules["google.cloud.firestore_v1"] = _mock_firestore
+    sys.modules["google.cloud.pubsub_v1"] = _mock_pubsub
+    sys.modules["google.cloud.storage"] = _mock_storage
+
+    # Pre-seed google.auth (and key sub-modules) with mocks so the
+    # import chain never reaches the broken cryptography C extension.
+    # google.auth is a separate distribution from google-cloud-* and
+    # google-protobuf, so replacing it does not affect TF/protobuf.
+    _mock_auth = MagicMock(name="mock_google_auth")
+    for _auth_key in [
+        "google.auth",
+        "google.auth.credentials",
+        "google.auth.default",
+        "google.auth.transport",
+        "google.auth.transport.grpc",
+        "google.auth.transport.requests",
+        "google.auth._default",
+        "google.auth.crypt",
+        "google.auth.crypt.es",
+    ]:
+        sys.modules.setdefault(_auth_key, _mock_auth)
+
+    _mock_oauth = MagicMock(name="mock_google_oauth2")
+    for _oauth_key in [
+        "google.oauth2",
+        "google.oauth2.service_account",
+        "google.oauth2.credentials",
+    ]:
+        sys.modules.setdefault(_oauth_key, _mock_oauth)
 
 
 _install_gcp_client_stubs()

--- a/tests/test_firestore_transactions.py
+++ b/tests/test_firestore_transactions.py
@@ -21,7 +21,7 @@ class TestFirestoreTransactions:
     def test_update_job_status_atomically_validates_transition(self):
         """Test 1: update_job_status() atomically reads current status and validates transition"""
         # Use Mock instead of real Transaction to avoid commit issues
-        mock_transaction = Mock(spec=firestore.Transaction)
+        mock_transaction = MagicMock()
         mock_transaction._read_only = False
         mock_transaction._id = b"test-transaction-id"
         mock_transaction._max_attempts = 5
@@ -49,7 +49,7 @@ class TestFirestoreTransactions:
     def test_update_job_status_raises_error_for_invalid_transition(self):
         """Test 2: update_job_status() raises ValueError for invalid transitions"""
         # Create mock transaction with required internal attributes
-        mock_transaction = Mock(spec=firestore.Transaction)
+        mock_transaction = MagicMock()
         mock_transaction._read_only = False
         mock_transaction._id = b"test-transaction-id"
         mock_transaction._max_attempts = 5
@@ -77,7 +77,7 @@ class TestFirestoreTransactions:
         # This tests Firestore's built-in retry mechanism via @firestore.transactional decorator
         # We verify the function is decorated and can be called multiple times
 
-        mock_transaction = Mock(spec=firestore.Transaction)
+        mock_transaction = MagicMock()
         mock_transaction._read_only = False
         mock_transaction._id = b"test-transaction-id"
         mock_transaction._max_attempts = 5
@@ -108,7 +108,7 @@ class TestFirestoreTransactions:
 
     def test_transaction_function_is_pure(self):
         """Test 4: Transaction function is pure (no external state mutations)"""
-        mock_transaction = Mock(spec=firestore.Transaction)
+        mock_transaction = MagicMock()
         mock_transaction._read_only = False
         mock_transaction._id = b"test-transaction-id"
         mock_transaction._max_attempts = 5
@@ -137,7 +137,7 @@ class TestFirestoreTransactions:
 
     def test_update_job_status_preserves_additional_fields(self):
         """Test 5: update_job_status() preserves additional_fields in update"""
-        mock_transaction = Mock(spec=firestore.Transaction)
+        mock_transaction = MagicMock()
         mock_transaction._read_only = False
         mock_transaction._id = b"test-transaction-id"
         mock_transaction._max_attempts = 5
@@ -172,7 +172,7 @@ class TestFirestoreTransactions:
 
     def test_update_job_status_raises_error_when_job_not_found(self):
         """Test that update_job_status raises ValueError when job document doesn't exist"""
-        mock_transaction = Mock(spec=firestore.Transaction)
+        mock_transaction = MagicMock()
         mock_transaction._read_only = False
         mock_transaction._id = b"test-transaction-id"
         mock_transaction._max_attempts = 5
@@ -193,7 +193,7 @@ class TestFirestoreTransactions:
 
     def test_update_job_status_logs_transition(self):
         """Test that update_job_status logs the status transition"""
-        mock_transaction = Mock(spec=firestore.Transaction)
+        mock_transaction = MagicMock()
         mock_transaction._read_only = False
         mock_transaction._id = b"test-transaction-id"
         mock_transaction._max_attempts = 5

--- a/worker.py
+++ b/worker.py
@@ -433,7 +433,8 @@ def update_job_status(transaction, job_ref, new_status, additional_fields=None):
         update_data.update(additional_fields)
 
     transaction.update(job_ref, update_data)
-    logger.info(f"Job {job_ref.id} status: {current_status} -> {new_status}")
+    new_val = new_status.value if isinstance(new_status, JobStatus) else new_status
+    logger.info(f"Job {job_ref.id} status: {current_status} -> {new_val}")
 
 
 def _is_claim_stale(claimed_at, now=None, threshold_seconds=None):


### PR DESCRIPTION
The test suite was completely broken — pytest crashed during collection
before any test could run. Three root causes:

1. conftest.py imported google.cloud.firestore to stub it, but the
   cryptography C extension is broken (pyo3_runtime.PanicException).
   Fixed by injecting mock modules directly into sys.modules instead
   of importing the real libraries, while preserving the google.*
   namespace packages that TensorFlow/protobuf depend on.

2. firestore.transactional decorator replaced real functions with
   MagicMock when firestore was mocked. Fixed by making the mock's
   transactional a pass-through lambda.

3. test_firestore_transactions used Mock(spec=firestore.Transaction)
   which fails when firestore.Transaction is itself a MagicMock.
   Fixed by using plain MagicMock().

Also fixed two minor bugs surfaced by the now-passing tests:
- compute_per_column_contributions returned numpy floats instead of
  Python floats (test_contributions assertion failure)
- update_job_status logged enum repr instead of value on Python 3.11+

Result: 122 passed, 14 skipped, 0 failures.

https://claude.ai/code/session_013uNJVH2UEF8bY744F3Q5Hd