### PR TITLE
Fix numerical stability: guard log(1)=0 division and single-attribute Concatenate crash

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -102,9 +102,10 @@ The `get_outliers_list()` function returns an aggregate reconstruction error per
 ### 3.4 Benchmark model variants
 Run systematic comparisons of AE vs. Chow-Liu tree on all built-in datasets. Record metrics (accuracy, lift, ROC AUC from `evaluate` command, plus outlier detection precision from `evaluate_on_condition`) and document which approach works best under what conditions. The Chow-Liu tree (task 10) provides a fast, principled baseline with no training hyperparameters — understanding when the AE adds value over the tree is a key research question.
 
-### 3.5 Fix numerical stability issues in loss computation
-- **Division by log(1) = 0**: `model/loss.py:62` and `model/base.py:121` normalize per-attribute crossentropy by `np.log(categories)`. If any attribute has cardinality 1, this is division by zero, producing `inf`/`NaN` loss. Commands that skip the Rule-of-9 filter (1.6) are vulnerable. Guard with `max(np.log(categories), epsilon)`.
-- **`Concatenate()` with single attribute**: `model/autoencoder.py:252` and `model/layers.py:39` call `Concatenate()(decoded_attrs)` which requires 2+ inputs. A single-column dataset passing Rule-of-9 crashes here.
+### ~~3.5 Fix numerical stability issues in loss computation~~ DONE
+- **Division by log(1) = 0**: `model/loss.py` and `model/base.py` already guarded with `max(int(categories), 2)`. Fixed the remaining unguarded location in `AutoencoderModel.__init__` (`model/autoencoder.py`) which computed `np.log(cardinality)` without clamping — now uses `np.log(max(cardinality, 2))`.
+- **`Concatenate()` with single attribute**: Fixed all three locations (`model/autoencoder.py` `build_decoder` and `build_decoder_hp`, `model/layers.py` `build_decoder`) to skip `Concatenate` and pass through the single tensor directly when there is only one attribute.
+- Added tests: `test_single_category_attribute_no_division_by_zero` (loss), `test_log_cardinalities_guards_cardinality_one` and `test_single_attribute_decoder_builds` (autoencoder).
 
 ### 3.6 Remove global eager mode
 `tf.config.run_functions_eagerly(True)` is set at module level in `model/base.py:8` and `model/variational_autoencoder.py:13`. This forces all TensorFlow functions in the process to run eagerly, causing 2-10x training slowdown. This was likely added for debugging. Remove it or guard behind a `DEBUG` environment variable.

--- a/model/autoencoder.py
+++ b/model/autoencoder.py
@@ -50,7 +50,7 @@ class AutoencoderModel:
         self.attribute_cardinalities = attribute_cardinalities
 
         log_cardinalities = [
-            np.log(cardinality) for cardinality in self.attribute_cardinalities
+            np.log(max(cardinality, 2)) for cardinality in self.attribute_cardinalities
         ]
         log_cardinalities_tensor = tf.constant(log_cardinalities, dtype=tf.float32)
         self.log_cardinalities_expanded = tf.expand_dims(
@@ -225,7 +225,7 @@ class AutoencoderModel:
             decoder_softmax = Dense(categories, activation="softmax")(x)
             decoded_attrs.append(decoder_softmax)
 
-        outputs = Concatenate()(decoded_attrs)
+        outputs = Concatenate()(decoded_attrs) if len(decoded_attrs) > 1 else decoded_attrs[0]
 
         return Model(decoder_inputs, outputs)
 
@@ -249,7 +249,7 @@ class AutoencoderModel:
             decoder_softmax = Dense(categories, activation="softmax")(x)
             decoded_attrs.append(decoder_softmax)
 
-        outputs = Concatenate()(decoded_attrs)
+        outputs = Concatenate()(decoded_attrs) if len(decoded_attrs) > 1 else decoded_attrs[0]
 
         return Model(decoder_inputs, outputs)
 

--- a/model/layers.py
+++ b/model/layers.py
@@ -36,7 +36,7 @@ def build_decoder(attribute_cardinalities, config, prior, num_classes):
         )(x)
         decoded_attrs.append(decoder_softmax)
 
-    outputs = Concatenate(name="decoder_concat")(decoded_attrs)
+    outputs = Concatenate(name="decoder_concat")(decoded_attrs) if len(decoded_attrs) > 1 else decoded_attrs[0]
 
     return Model(decoder_inputs, outputs)
 

--- a/tests/model/test_autoencoder.py
+++ b/tests/model/test_autoencoder.py
@@ -32,3 +32,21 @@ class TestAutoencoderModel(unittest.TestCase):
         y_pred = np.array([[1.0, 1.0], [3.0, 2.0]])
         result = self.autoencoder.masked_mse(y_true, y_pred)
         self.assertIsNotNone(result)
+
+    def test_log_cardinalities_guards_cardinality_one(self):
+        """Cardinality-1 attributes must not produce log(1)=0 in log_cardinalities."""
+        model = AutoencoderModel([1, 3, 1])
+        log_vals = model.log_cardinalities_expanded.numpy().flatten()
+        for v in log_vals:
+            self.assertGreater(v, 0, "log_cardinalities contains zero (log(1)=0)")
+
+    def test_single_attribute_decoder_builds(self):
+        """Decoder with a single attribute must not crash on Concatenate."""
+        model = AutoencoderModel([4])
+        df = pd.DataFrame({"c": ["A", "B", "C", "D"] * 5})
+        model.split_train_test(df, test_size=0.2)
+        config = {"encoder_layers": 1, "decoder_layers": 1, "latent_space_dim": 2,
+                  "encoder_units_1": 8, "decoder_units_1": 8,
+                  "encoder_batch_norm_1": False, "decoder_batch_norm_1": False}
+        autoencoder = model.build_autoencoder(config)
+        self.assertIsNotNone(autoencoder)

--- a/tests/model/test_loss.py
+++ b/tests/model/test_loss.py
@@ -51,3 +51,14 @@ class TestCustomLossAE(unittest.TestCase):
         self.assertEqual(config["percentile"], 90)
         self.assertIn("attribute_cardinalities", config)
         self.assertEqual(config["attribute_cardinalities"], self.attribute_cardinalities)
+
+    def test_single_category_attribute_no_division_by_zero(self):
+        """Cardinality-1 attributes must not cause inf/NaN via log(1)=0 division."""
+        cardinalities = [1, 3]  # first attribute has cardinality 1
+        y_true = np.array([[1, 1, 0, 0], [1, 0, 1, 0]], dtype=np.float32)
+        y_pred = np.array(
+            [[1.0, 0.8, 0.1, 0.1], [1.0, 0.1, 0.8, 0.1]], dtype=np.float32
+        )
+        loss_fn = CustomCategoricalCrossentropyAE(attribute_cardinalities=cardinalities)
+        result = loss_fn(y_true, y_pred)
+        self.assertTrue(np.isfinite(result.numpy()), f"Loss is not finite: {result.numpy()}")


### PR DESCRIPTION
- Guard log_cardinalities in AutoencoderModel.__init__ with max(cardinality, 2)
  to prevent division by zero when cardinality is 1 (loss.py and base.py were
  already guarded but autoencoder.py was not)
- Handle single-attribute datasets in all three decoder builders by skipping
  Concatenate() (which requires 2+ inputs) and passing the single tensor through
- Add tests for both edge cases

https://claude.ai/code/session_018v2XEQd8jHtDr1Ed5ziPh7