### PR TITLE
ci: add multi-job CI pipeline with Python linting and frontend checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,34 @@
 name: CI
+
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+
+# Cancel in-progress runs for the same branch/PR
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
+  # ──────────────────────────────────────────────
+  # Python
+  # ──────────────────────────────────────────────
+  python-lint:
+    name: Python Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - run: pip install ruff
+      - run: ruff check .
+
+  python-test:
+    name: Python Tests
+    needs: python-lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,3 +43,40 @@ jobs:
       - run: python -m pytest tests/ -v --tb=short -x
         env:
           TF_CPP_MIN_LOG_LEVEL: "3"
+
+  # ──────────────────────────────────────────────
+  # Frontend
+  # ──────────────────────────────────────────────
+  frontend-build:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run build
+
+  frontend-test:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm test -- --forceExit
+        env:
+          NODE_ENV: test

--- a/dataset/loader.py
+++ b/dataset/loader.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 from sklearn.preprocessing import StandardScaler
-from typing import Dict, Any, List, Tuple, Optional
 import io
 import warnings 
 from pandas.errors import PerformanceWarning

--- a/evaluate/evaluator.py
+++ b/evaluate/evaluator.py
@@ -104,7 +104,7 @@ class Evaluator:
 
     def evaluate(self, data, vectorizer, project_data, variable_types, output_path):
 
-        logger.info(f"Imputing missing values....")
+        logger.info("Imputing missing values....")
         # modified_data = self.impute_missing_values(data)
 
         logger.info("Predicting....")

--- a/frontend/server/__tests__/middleware/errorHandler.test.ts
+++ b/frontend/server/__tests__/middleware/errorHandler.test.ts
@@ -6,6 +6,15 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import request from 'supertest';
 import express, { Express, Request, Response, NextFunction } from 'express';
 
+// Mock Cloud Logging so production-mode tests don't need GCP credentials
+jest.mock('@google-cloud/logging-winston', () => ({
+  LoggingWinston: jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    log: jest.fn(),
+    levels: {},
+  })),
+}));
+
 describe('Error handler middleware', () => {
   let app: Express;
   const originalEnv = process.env.NODE_ENV;

--- a/main.py
+++ b/main.py
@@ -32,7 +32,6 @@ import pandas as pd
 import yaml
 from sklearn.model_selection import train_test_split
 
-from google.cloud import storage
 from dataset.loader import DataLoader
 from evaluate.evaluator import Evaluator
 from evaluate.generator import Generator
@@ -264,7 +263,7 @@ def run_training_pipeline(df, config_path, output_path, model_name="AE", prior="
     model = get_model(model_name, cardinalities)
     trainer = Trainer(model, config)
 
-    logger.info(f"Training model....")
+    logger.info("Training model....")
     model, history = trainer.train(
         dataset=X_train, prior=prior,
         X_train=X_train, X_test=X_test,
@@ -338,7 +337,7 @@ def train(
     ) = define_necessary_elements(data, drop_columns, rename_columns, interest_columns)
 
     # 3. Initialize Loader
-    logger.info(f"Loading data....")
+    logger.info("Loading data....")
     data_loader = DataLoader(
         drop_columns,
         rename_columns,
@@ -363,12 +362,12 @@ def train(
     )
 
     # 6. Build and Train model
-    logger.info(f"Loading model....")
+    logger.info("Loading model....")
     model = get_model(model_name, cardinalities)
 
     trainer = Trainer(model, config_dict)
 
-    logger.info(f"Training model....")
+    logger.info("Training model....")
     model, history = trainer.train(
         dataset=X_train, prior=prior,
         X_train=X_train, X_test=X_test,
@@ -377,7 +376,7 @@ def train(
     # 10. Save Results
     logger.info("Saving model....")
     save_model(model, output, vectorizer=vectorizer)
-    logger.info(f"Saving history....")
+    logger.info("Saving history....")
     save_history(history, output)
     logger.info("Saving plots....")
     model_analysis(history, output, model_name)
@@ -447,7 +446,7 @@ def search_hyperparameters(
     project_data, metadata = data_loader.load_data(data)
     variable_types = metadata.get("variable_types", {})
 
-    logger.info(f"Loading config from config file....")
+    logger.info("Loading config from config file....")
     with open(config, "r") as file:
         config = yaml.safe_load(file)
 
@@ -457,12 +456,12 @@ def search_hyperparameters(
         test_size=config.get("test_size", 0.2),
     )
 
-    logger.info(f"Loading model....")
+    logger.info("Loading model....")
     model = get_model(model_name, cardinalities)
 
     trainer = Trainer(model, config)
 
-    logger.info(f"Searching hyperparameters....")
+    logger.info("Searching hyperparameters....")
     best_hps = trainer.search_hyperparameters(
         dataset=X_train, prior=prior,
         X_train=X_train, X_test=X_test,
@@ -522,14 +521,14 @@ def evaluate(
 
     set_seed(seed)
 
-    logger.info(f"Loading model....")
+    logger.info("Loading model....")
     model = load_model(model_path)
 
-    logger.info(f"Loading data....")
+    logger.info("Loading data....")
     project_data, metadata = data_loader.load_data(data)
     variable_types = metadata.get("variable_types", {})
 
-    logger.info(f"Transforming the data....")
+    logger.info("Transforming the data....")
     saved_vectorizer = load_vectorizer(model_path)
     if saved_vectorizer is not None:
         # Use the training-fitted vectorizer so one-hot width matches the model
@@ -614,7 +613,7 @@ def find_outliers(
     ) = define_necessary_elements(data, drop_columns, rename_columns, interest_columns)
 
     # 2. Initialize Loader
-    logger.info(f"Loading data...")
+    logger.info("Loading data...")
     data_loader = DataLoader(
         drop_columns,
         rename_columns,
@@ -808,7 +807,7 @@ def generate(
 
     set_seed(seed)
 
-    logger.info(f"Loading model....")
+    logger.info("Loading model....")
     model = load_model(model_path)
     decoder = model.decoder
 
@@ -824,7 +823,7 @@ def generate(
         additional_interest_columns,
     ) = define_necessary_elements(data, drop_columns, rename_columns, interest_columns)
 
-    logger.info(f"Loading data....")
+    logger.info("Loading data....")
     data_loader = DataLoader(
         drop_columns,
         rename_columns,
@@ -836,7 +835,7 @@ def generate(
     project_data, metadata = data_loader.load_data(data)
     variable_types = metadata.get("variable_types", {})
 
-    logger.info(f"Creating the vectorizer....")
+    logger.info("Creating the vectorizer....")
     saved_vectorizer = load_vectorizer(model_path)
     if saved_vectorizer is not None:
         project_data = _clean_for_saved_vectorizer(project_data, saved_vectorizer)
@@ -861,7 +860,7 @@ def generate(
             for ind, val in zip(features_indices, desired_values)
         ]
 
-    logger.info(f"Generating samples....")
+    logger.info("Generating samples....")
 
     # Compute latent-space statistics from the encoder on training data
     # (the VAE's get_config() does not store prior_means / prior_log_vars)
@@ -1078,7 +1077,7 @@ def pca_baseline(
 
     df_combined = pd.concat([reconstruction_errors, outlier_dataset], axis=1)
 
-    metrics = evaluate_errors(df_combined, column_to_condition, outlier_values)
+    evaluate_errors(df_combined, column_to_condition, outlier_values)
 
 
 if __name__ == "__main__":

--- a/model/loss.py
+++ b/model/loss.py
@@ -1,47 +1,5 @@
 import numpy as np
 import tensorflow as tf
-from tensorflow import keras
-
-
-# @keras.utils.register_keras_serializable()
-# class CustomCategoricalCrossentropyAE(tf.keras.losses.Loss):
-#     def __init__(self, attribute_cardinalities, name="custom_categorical_crossentropy"):
-#         super(CustomCategoricalCrossentropyAE, self).__init__(name=name)
-#         self.attribute_cardinalities = attribute_cardinalities
-#         log_cardinalities = [
-#             np.log(cardinality) for cardinality in self.attribute_cardinalities
-#         ]
-#         log_cardinalities_tensor = tf.constant(log_cardinalities, dtype=tf.float32)
-#         self.log_cardinalities_expanded = tf.expand_dims(
-#             log_cardinalities_tensor, axis=-1
-#         )
-#
-#     def call(self, y_true, y_pred):
-#
-#         xent_loss = 0
-#         start_idx = 0
-#
-#         for categories in self.attribute_cardinalities:
-#             x_attr = y_true[:, start_idx : start_idx + categories]
-#             y_attr = y_pred[:, start_idx : start_idx + categories]
-#
-#             x_attr = tf.keras.backend.cast(x_attr, "float32")
-#             y_attr = tf.keras.backend.cast(y_attr, "float32")
-#
-#             xent_loss += tf.keras.backend.mean(
-#                 tf.keras.backend.categorical_crossentropy(x_attr, y_attr)
-#             ) / np.log(categories)
-#
-#             start_idx += categories
-#
-#         return xent_loss / len(self.attribute_cardinalities)
-#
-#     def get_config(self):
-#         return {"attribute_cardinalities": self.attribute_cardinalities}
-
-
-import tensorflow as tf
-import numpy as np
 
 @tf.keras.utils.register_keras_serializable()
 class CustomCategoricalCrossentropyAE(tf.keras.losses.Loss):

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,19 @@
+# Ruff linter configuration
+# https://docs.astral.sh/ruff/
+
+target-version = "py310"
+
+exclude = [
+    "notebooks/",
+    "scripts/notebooks/",
+    ".venv/",
+    "venv/",
+]
+
+[lint]
+# F: Pyflakes — catches unused imports, undefined names, redefinitions
+# E9: Runtime errors — syntax errors
+select = ["F", "E9"]
+
+# F811: redefined-while-unused — common in notebooks and conditional imports
+ignore = ["F811"]

--- a/test_reconstruction.py
+++ b/test_reconstruction.py
@@ -1,6 +1,5 @@
 
 import pandas as pd
-import numpy as np
 import logging
 from features.transform import Table2Vector
 
@@ -29,7 +28,7 @@ def test_reconstruction_logic():
 
     # 4. Simulate Model Reconstruction (just using the same data for perfect reconstruction, 
     # but let's change one slightly to simulate error)
-    reconstruction_vals = vectorized_df.values.copy()
+    vectorized_df.values.copy()
     
     # Let's say for row 1 (B, Y), the model predicts (A, Y)
     # col1 has categories A, B, C. A is index 0, B is index 1.

--- a/test_worker_local.py
+++ b/test_worker_local.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from unittest.mock import MagicMock, patch
 
 # --- STEP 1: MOCK CLOUD SERVICES ---

--- a/tests/features/test_data_leakage.py
+++ b/tests/features/test_data_leakage.py
@@ -314,7 +314,7 @@ class TestVectorizerPersistence(unittest.TestCase):
 
     def test_save_load_vectorizer_roundtrip(self):
         import tempfile, os, joblib
-        from utils import save_model, load_vectorizer
+        from utils import load_vectorizer
 
         train_df = pd.DataFrame({
             "q1": ["a", "b", "c", "a", "b", "c"],

--- a/tests/test_ack_extension.py
+++ b/tests/test_ack_extension.py
@@ -5,10 +5,8 @@ Tests that worker extends Pub/Sub message ack deadline during processing
 to prevent timeout and redelivery for 10-15 minute jobs.
 """
 
-import pytest
-from unittest.mock import Mock, MagicMock, patch, call
+from unittest.mock import Mock, patch
 import time
-import threading
 
 
 def test_ack_extender_extends_deadline_periodically():

--- a/tests/test_contributions.py
+++ b/tests/test_contributions.py
@@ -6,7 +6,6 @@ reconstruction loss into per-attribute percentages for outlier explanation.
 """
 
 import numpy as np
-import pytest
 from evaluate.outliers import compute_per_column_contributions
 
 

--- a/tests/test_csv_validation.py
+++ b/tests/test_csv_validation.py
@@ -5,9 +5,7 @@ Tests encoding detection, structure validation, size limits, and edge cases
 to ensure robust validation before worker processes files.
 """
 
-import io
 import pytest
-import pandas as pd
 from worker import validate_csv
 
 

--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -10,7 +10,6 @@ fresh each time, so monkeypatch works correctly.
 
 import pytest
 import sys
-import os
 from unittest.mock import MagicMock, patch
 
 # Mock heavyweight imports before importing worker so the module loads quickly

--- a/tests/test_message_validation.py
+++ b/tests/test_message_validation.py
@@ -6,7 +6,7 @@ and rejects malformed messages.
 """
 
 import pytest
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock
 import json
 
 

--- a/tests/test_status_transitions.py
+++ b/tests/test_status_transitions.py
@@ -8,7 +8,6 @@ Tests enforce business rules:
 - Error and canceled states reachable from any state
 """
 
-import pytest
 from worker import JobStatus, is_valid_transition
 
 

--- a/train/task.py
+++ b/train/task.py
@@ -15,11 +15,8 @@ Usage (called by Vertex AI):
 
 import argparse
 import logging 
-import json
-import os
 import numpy as np
 import pandas as pd
-import tensorflow as tf
 from google.cloud import storage, firestore
 from dataset.loader import DataLoader
 from features.transform import Table2Vector

--- a/utils.py
+++ b/utils.py
@@ -267,10 +267,10 @@ def evaluate_errors(error_data, column, values):
         "precision@10",
         "precision@50",
         "precision@100",
-        f"map",
-        f"map@68",
+        "map",
+        "map@68",
         f"ndcg@{total_w_error}",
-        f"mrr",
+        "mrr",
     ]
     evaluation = evaluate(qrels, run, metrics)
 


### PR DESCRIPTION
Expand the single-job CI workflow into four parallel jobs:
- Python Lint (ruff) — catches bug-class errors (Pyflakes + E9)
- Python Tests (pytest) — runs after lint passes
- Frontend Build (Vite) — verifies the React app compiles
- Frontend Tests (Jest) — runs all 171 server/client tests

Also adds ruff.toml config, fixes unused imports/variables across the
codebase, removes dead commented-out code in model/loss.py, and mocks
Cloud Logging in errorHandler tests so they pass without GCP credentials.

https://claude.ai/code/session_01NWTH3i8kTDbvYrt4hxFU3y