### PR TITLE
docs: add PR workflow section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,10 @@ GCS_BUCKET_NAME=your-bucket-name
 PUBSUB_SUBSCRIPTION_ID=job-upload-topic-sub
 ```
 
+## PR Workflow
+
+Once you are done with your work, create a pull request and then start monitoring it for review comments (in particular from Codex, which auto-reviews PRs in this repo). You have `gh` and `GITHUB_TOKEN` available — use them to open the PR, poll for new review comments, and respond to or address feedback as it arrives. Don't consider a task finished just because the code is pushed: stay on the PR until reviews have been addressed.
+
 ## Cloud Credentials
 
 This repo uses the **cloud-bootstrap** skill to manage encrypted GCP credentials.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,9 @@ PUBSUB_SUBSCRIPTION_ID=job-upload-topic-sub
 
 ## PR Workflow
 
-Once you are done with your work, create a pull request and then start monitoring it for review comments (in particular from Codex, which auto-reviews PRs in this repo). You have `gh` and `GITHUB_TOKEN` available — use them to open the PR, poll for new review comments, and respond to or address feedback as it arrives. Don't consider a task finished just because the code is pushed: stay on the PR until reviews have been addressed.
+Once you are done with your work, create a pull request and then start monitoring it for review comments. Codex is configured to auto-review every PR in this repo, so always wait for its review and address its feedback before considering the task done — code being pushed is not the finish line.
+
+For GitHub interactions (opening the PR, fetching review comments, replying, checking CI), prefer the GitHub MCP tools (`mcp__github__*`) when they are available. Fall back to the `gh` CLI with `GITHUB_TOKEN` only if the MCP tools are not present in the current environment or a specific MCP call fails.
 
 ## Cloud Credentials
 


### PR DESCRIPTION
Document that Claude should open a PR after finishing work and stay on
it to address review comments (notably from Codex auto-review) rather
than treating the task as done at push time.