### PR TITLE
feat: make Rule-of-9 threshold configurable (TASKS.md 3.1)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -102,8 +102,15 @@ Added `tests/test_reconstruction_error.py` with 9 tests: unit tests for the help
 
 ## 3. Improve Model Quality and Configurability
 
-### 3.1 Make the "Rule of 9" threshold configurable
-The max-unique-values threshold of 9 is hardcoded in `DataLoader.prepare_original_dataset()` (line 439) and duplicated in `main.py` `train`/`find_outliers` commands. Make this a CLI parameter and config option so users can adjust it for their specific datasets.
+### ~~3.1 Make the "Rule of 9" threshold configurable~~ DONE
+Renamed the "Rule of 9" to the "Rule of N" across the codebase and made the max-unique-values threshold configurable end-to-end. `DEFAULT_MAX_UNIQUE_VALUES = 9` is now exported from `dataset/loader.py` as the single source of truth; every call site honours an override.
+
+- **`DataLoader`**: constructor accepts `max_unique_values` (default `None` → module default). Every loader entry point (`load_2015`, `load_2017`, `load_pennycook_*`, `load_uploaded_csv`, etc.) inherits it via `self.max_unique_values`. `prepare_original_dataset()` also accepts a per-call override. Thresholds below 2 raise `ValueError` because the filter also drops `n_unique <= 1`, so `N < 2` would drop every column.
+- **`main.py` helpers**: `prepare_for_categorical`, `_clean_and_build_vectorizer`, `prepare_for_model`, `prepare_for_training`, and `run_training_pipeline` all accept `max_unique_values` and thread it through consistently. `run_training_pipeline` also reads a `max_unique_values` key from the YAML config.
+- **CLI options**: added `--max_unique_values` to `train`, `search_hyperparameters`, `evaluate`, `find_outliers`, `chow_liu_outliers`, `generate`, and `pca_baseline`. CLI flag > YAML config key > built-in default precedence. `evaluate_on_condition` does not vectorize (reads pre-computed errors.csv), so no flag was added there.
+- **`worker.py` / `train/task.py`**: inline Rule-of-N loops read from the `MAX_UNIQUE_VALUES` environment variable via a `_resolve_max_unique_values()` helper (with warning + fallback for invalid values and thresholds below 2). Setting `MAX_UNIQUE_VALUES` propagates from worker to Vertex AI containers through normal env-var inheritance.
+- **Error messages / logs** now cite the configured threshold (`"Rule of N (N=15)"`, `"more than 15 unique values"`) so operators can see which threshold was in effect for any given run. The `NO_USABLE_COLUMNS` payload the frontend receives also reflects the active threshold.
+- **Tests**: new `tests/test_rule_of_n.py` (22 tests) covering the default-unchanged behaviour, DataLoader with high / low / per-call overrides, constant-column independence from N, `ValueError` on `N < 2`, `main.py` helpers threading the threshold through to vectorized-matrix widths, and env-var parsing for both `worker._resolve_max_unique_values` and `train.task._resolve_max_unique_values` (valid ints, empty/missing, non-integer, below-2 fallback). Full test suite: 216 passed, 12 skipped.
 
 ### 3.2 Support custom model configs for uploaded data
 When a user uploads a CSV through the web UI, the system should either auto-select reasonable hyperparameters based on the data shape or allow the user to choose a config preset. Currently, the uploaded data path does not specify which config to use.

--- a/dataset/loader.py
+++ b/dataset/loader.py
@@ -33,6 +33,7 @@ class DataLoader:
         additional_rename_columns=None,
         additional_columns_of_interest=None,
         max_unique_values=None,
+        apply_rule_of_n=True,
     ):
         self.DROP_COLUMNS = drop_columns
         self.RENAME_COLUMNS = rename_columns
@@ -56,6 +57,19 @@ class DataLoader:
                 "values."
             )
         self.max_unique_values = int(max_unique_values)
+        # When ``False``, ``prepare_original_dataset`` skips the
+        # Rule-of-N filter entirely — numeric binning, NaN-fill, and
+        # string casting still run, but every surviving column is kept
+        # regardless of cardinality. Scoring paths set this to ``False``
+        # when a saved training-time vectorizer is present so that the
+        # vectorizer (not the loader) is the authoritative source of
+        # truth on which columns the model expects. Without this,
+        # columns whose training-time cardinality exceeded the current
+        # loader threshold would be silently dropped here and then
+        # backfilled as constant ``"missing"`` values by
+        # ``_clean_for_saved_vectorizer``, corrupting model inputs
+        # (Codex P1 PR#49).
+        self.apply_rule_of_n = bool(apply_rule_of_n)
 
     def load_2015(self):
         url = "data/sadc_2015only_national.csv"
@@ -503,7 +517,13 @@ class DataLoader:
 
         return continuous_columns
 
-    def prepare_original_dataset(self, project_data, replacements, max_unique_values=None):
+    def prepare_original_dataset(
+        self,
+        project_data,
+        replacements,
+        max_unique_values=None,
+        apply_rule_of_n=None,
+    ):
         """
         1. Bins numeric data (making it categorical)
         2. Fills remaining NaN values in categorical columns with "missing"
@@ -515,6 +535,13 @@ class DataLoader:
         4. Returns cleaned dataframe and metadata (ignored_columns +
            variable_types)
 
+        When ``apply_rule_of_n`` is ``False`` (either per-call or via
+        the loader instance attribute), step 3 is skipped: every column
+        is kept regardless of cardinality, still cast to string. Scoring
+        paths that load a trained vectorizer use this so the vectorizer
+        (not the loader) is the authoritative source of truth on which
+        columns the model expects.
+
         This mirrors the inline cleaning in ``worker.py`` and the shared
         ``main.prepare_for_categorical`` helper so that the upload path
         produces the same clean frame as the CLI / worker paths.
@@ -525,6 +552,8 @@ class DataLoader:
             raise ValueError(
                 f"max_unique_values must be >= 2 (got {max_unique_values})"
             )
+        if apply_rule_of_n is None:
+            apply_rule_of_n = self.apply_rule_of_n
 
         # Apply replacements
         for k, v in replacements.items():
@@ -548,30 +577,39 @@ class DataLoader:
         # is a no-op on the newly-created ``*_cat`` columns.
         project_data = project_data.fillna("missing")
 
-        # 3. Rule of N: keep columns with 2..N unique values.
-        # Both extremes are dropped — > N values is too high-cardinality for
-        # the autoencoder to learn a meaningful one-hot, and a single
-        # unique value provides no signal at all.
         kept_columns = []
         ignored_columns = []
 
-        for col in project_data.columns:
-            n_unique = project_data[col].nunique(dropna=True)
-
-            if 1 < n_unique <= max_unique_values:
-                kept_columns.append(col)
-                # kept as string for the Autoencoder
+        if not apply_rule_of_n:
+            # Scoring path with a saved vectorizer: skip cardinality
+            # filtering entirely and let the vectorizer decide which
+            # columns the model expects. We still cast to string so
+            # downstream one-hot encoding receives consistent dtypes.
+            for col in project_data.columns:
                 project_data[col] = project_data[col].astype(str)
-            else:
-                if n_unique <= 1:
-                    reason = "Low cardinality (<= 1 unique value)"
+                kept_columns.append(col)
+        else:
+            # 3. Rule of N: keep columns with 2..N unique values.
+            # Both extremes are dropped — > N values is too high-cardinality
+            # for the autoencoder to learn a meaningful one-hot, and a
+            # single unique value provides no signal at all.
+            for col in project_data.columns:
+                n_unique = project_data[col].nunique(dropna=True)
+
+                if 1 < n_unique <= max_unique_values:
+                    kept_columns.append(col)
+                    # kept as string for the Autoencoder
+                    project_data[col] = project_data[col].astype(str)
                 else:
-                    reason = f"High cardinality (> {max_unique_values} unique values)"
-                ignored_columns.append({
-                    "name": col,
-                    "unique_values": int(n_unique),
-                    "reason": reason,
-                })
+                    if n_unique <= 1:
+                        reason = "Low cardinality (<= 1 unique value)"
+                    else:
+                        reason = f"High cardinality (> {max_unique_values} unique values)"
+                    ignored_columns.append({
+                        "name": col,
+                        "unique_values": int(n_unique),
+                        "reason": reason,
+                    })
 
         # 4. Construct Final dataframe
         clean_df = project_data[kept_columns].copy()

--- a/dataset/loader.py
+++ b/dataset/loader.py
@@ -2,24 +2,60 @@ import numpy as np
 import pandas as pd
 from sklearn.preprocessing import StandardScaler
 import io
-import warnings 
+import warnings
 from pandas.errors import PerformanceWarning
 
 # Silence the gramentation warning so the terminal stays clean
 warnings.simplefilter(action='ignore', category=PerformanceWarning)
+
+# Default upper bound on the number of unique values a column may have to
+# survive the "Rule of 9" cardinality filter. Columns with more than this
+# many unique values are treated as too high-cardinality for the
+# autoencoder and dropped; columns with <= 1 unique values are also
+# dropped because they carry no signal. This threshold is configurable
+# per-DataLoader via the ``max_unique_values`` constructor argument and
+# via the CLI / YAML config (TASKS.md 3.1); the constant is re-exported
+# so downstream modules can reference the same default.
+DEFAULT_MAX_UNIQUE_VALUES = 9
+
 
 class DataLoader:
     """
     Class to handle data loading and preprocessing for the project.
     """
 
-    def __init__(self, drop_columns, rename_columns, columns_of_interest, additional_drop_columns=None, additional_rename_columns=None, additional_columns_of_interest=None):
+    def __init__(
+        self,
+        drop_columns,
+        rename_columns,
+        columns_of_interest,
+        additional_drop_columns=None,
+        additional_rename_columns=None,
+        additional_columns_of_interest=None,
+        max_unique_values=None,
+    ):
         self.DROP_COLUMNS = drop_columns
         self.RENAME_COLUMNS = rename_columns
         self.COLUMNS_OF_INTEREST = columns_of_interest
         self.ADDITIONAL_DROP_COLUMNS = additional_drop_columns
         self.ADDITIONAL_RENAME_COLUMNS = additional_rename_columns
         self.ADDITIONAL_COLUMNS_OF_INTEREST = additional_columns_of_interest
+        # Rule-of-N threshold: ``None`` means use the module default.
+        # Stored as an attribute so every loader method that ultimately
+        # calls ``prepare_original_dataset`` (e.g. ``load_2017``,
+        # ``load_uploaded_csv``) inherits the caller's configured
+        # threshold without needing to thread the value through each
+        # dataset-specific entry point (TASKS.md 3.1).
+        if max_unique_values is None:
+            max_unique_values = DEFAULT_MAX_UNIQUE_VALUES
+        if max_unique_values < 2:
+            raise ValueError(
+                f"max_unique_values must be >= 2 (got {max_unique_values}); "
+                "a threshold below 2 would drop every column since the "
+                "Rule-of-N filter also rejects columns with <= 1 unique "
+                "values."
+            )
+        self.max_unique_values = int(max_unique_values)
 
     def load_2015(self):
         url = "data/sadc_2015only_national.csv"
@@ -467,12 +503,15 @@ class DataLoader:
 
         return continuous_columns
 
-    def prepare_original_dataset(self, project_data, replacements):
+    def prepare_original_dataset(self, project_data, replacements, max_unique_values=None):
         """
         1. Bins numeric data (making it categorical)
         2. Fills remaining NaN values in categorical columns with "missing"
-        3. Applies the Rule of 9: keep columns with 2-9 unique values,
-           drop anything with <= 1 or > 9 unique values
+        3. Applies the Rule of N: keep columns with 2..N unique values,
+           drop anything with <= 1 or > N unique values. ``N`` defaults to
+           ``self.max_unique_values`` (historically 9) but can be
+           overridden per-call via ``max_unique_values`` — CLI callers
+           usually set it on the DataLoader instead.
         4. Returns cleaned dataframe and metadata (ignored_columns +
            variable_types)
 
@@ -480,6 +519,13 @@ class DataLoader:
         ``main.prepare_for_categorical`` helper so that the upload path
         produces the same clean frame as the CLI / worker paths.
         """
+        if max_unique_values is None:
+            max_unique_values = self.max_unique_values
+        if max_unique_values < 2:
+            raise ValueError(
+                f"max_unique_values must be >= 2 (got {max_unique_values})"
+            )
+
         # Apply replacements
         for k, v in replacements.items():
             if k in project_data.columns: # ensure code doesn't crash if col doesn't exist in current dataset
@@ -495,26 +541,24 @@ class DataLoader:
         project_data = DataLoader.convert_to_categorical(project_data, numeric_vars) # Convert numeric columns into categorical bins
 
         # 2. Fill NaN in non-numeric columns with the literal string
-        # "missing" so that (a) the Rule-of-9 count below treats missing as
+        # "missing" so that (a) the Rule-of-N count below treats missing as
         # a real category and (b) downstream ``astype(str)`` does not turn
         # NaN into the string "nan". ``convert_to_categorical`` already
         # handles NaN for numeric columns via its "missing" bin, so this
         # is a no-op on the newly-created ``*_cat`` columns.
         project_data = project_data.fillna("missing")
 
-        # 3. Rule of 9: keep columns with 2-9 unique values.
-        # Both extremes are dropped — > 9 values is too high-cardinality for
+        # 3. Rule of N: keep columns with 2..N unique values.
+        # Both extremes are dropped — > N values is too high-cardinality for
         # the autoencoder to learn a meaningful one-hot, and a single
         # unique value provides no signal at all.
         kept_columns = []
         ignored_columns = []
 
-        MAX_UNIQUE = 9
-
         for col in project_data.columns:
             n_unique = project_data[col].nunique(dropna=True)
 
-            if 1 < n_unique <= MAX_UNIQUE:
+            if 1 < n_unique <= max_unique_values:
                 kept_columns.append(col)
                 # kept as string for the Autoencoder
                 project_data[col] = project_data[col].astype(str)
@@ -522,7 +566,7 @@ class DataLoader:
                 if n_unique <= 1:
                     reason = "Low cardinality (<= 1 unique value)"
                 else:
-                    reason = f"High cardinality (> {MAX_UNIQUE} unique values)"
+                    reason = f"High cardinality (> {max_unique_values} unique values)"
                 ignored_columns.append({
                     "name": col,
                     "unique_values": int(n_unique),

--- a/main.py
+++ b/main.py
@@ -631,7 +631,9 @@ def search_hyperparameters(
     help=(
         "Upper bound on unique values per column for the Rule-of-N filter "
         "(default 9). Only applies when no saved vectorizer is present; "
-        "otherwise the training-fitted vectorizer dictates kept columns."
+        "when a saved vectorizer exists the Rule-of-N filter is bypassed "
+        "entirely so the training-fitted vectorizer is the authoritative "
+        "source of truth on kept columns."
     ),
     type=int,
     default=None,
@@ -654,6 +656,21 @@ def evaluate(
         max_unique_values if max_unique_values is not None else DEFAULT_MAX_UNIQUE_VALUES
     )
 
+    set_seed(seed)
+
+    logger.info("Loading model....")
+    model = load_model(model_path)
+
+    # Load the training-fitted vectorizer *before* constructing the
+    # DataLoader so that we can disable the Rule-of-N filter when a
+    # saved vectorizer is present. Otherwise columns whose training-time
+    # cardinality exceeded the current loader threshold would be
+    # silently dropped here and backfilled as constant ``"missing"``
+    # values by ``_clean_for_saved_vectorizer`` below, corrupting model
+    # inputs (Codex P1 PR#49).
+    saved_vectorizer = load_vectorizer(model_path)
+    apply_rule_of_n = saved_vectorizer is None
+
     data_loader = DataLoader(
         drop_columns,
         rename_columns,
@@ -662,19 +679,14 @@ def evaluate(
         additional_rename_columns=additional_rename_columns,
         additional_columns_of_interest=additional_interest_columns,
         max_unique_values=effective_max_unique,
+        apply_rule_of_n=apply_rule_of_n,
     )
-
-    set_seed(seed)
-
-    logger.info("Loading model....")
-    model = load_model(model_path)
 
     logger.info("Loading data....")
     project_data, metadata = data_loader.load_data(data)
     variable_types = metadata.get("variable_types", {})
 
     logger.info("Transforming the data....")
-    saved_vectorizer = load_vectorizer(model_path)
     if saved_vectorizer is not None:
         # Use the training-fitted vectorizer so one-hot width matches the model
         project_data = _clean_for_saved_vectorizer(project_data, saved_vectorizer)
@@ -739,7 +751,9 @@ def evaluate(
     help=(
         "Upper bound on unique values per column for the Rule-of-N filter "
         "(default 9). Only applies when no saved vectorizer is present; "
-        "otherwise the training-fitted vectorizer dictates kept columns."
+        "when a saved vectorizer exists the Rule-of-N filter is bypassed "
+        "entirely so the training-fitted vectorizer is the authoritative "
+        "source of truth on kept columns."
     ),
     type=int,
     default=None,
@@ -773,6 +787,13 @@ def find_outliers(
         max_unique_values if max_unique_values is not None else DEFAULT_MAX_UNIQUE_VALUES
     )
 
+    # Load the training-fitted vectorizer *before* constructing the
+    # DataLoader so that we can disable the Rule-of-N filter when a
+    # saved vectorizer is present (Codex P1 PR#49). See ``evaluate`` for
+    # the full rationale.
+    saved_vectorizer = load_vectorizer(model_path)
+    apply_rule_of_n = saved_vectorizer is None
+
     # 2. Initialize Loader
     logger.info("Loading data...")
     data_loader = DataLoader(
@@ -783,6 +804,7 @@ def find_outliers(
         additional_rename_columns=additional_rename_columns,
         additional_columns_of_interest=additional_interest_columns,
         max_unique_values=effective_max_unique,
+        apply_rule_of_n=apply_rule_of_n,
     )
 
     # 3. Load data -- all loaders return (DataFrame, metadata_dict)
@@ -791,7 +813,6 @@ def find_outliers(
 
     # 4. Clean and vectorize
     logger.info("Transforming the data....")
-    saved_vectorizer = load_vectorizer(model_path)
     if saved_vectorizer is not None:
         project_data = _clean_for_saved_vectorizer(project_data, saved_vectorizer)
         vectorized_df = saved_vectorizer.transform(project_data).astype("float32")
@@ -998,7 +1019,10 @@ def chow_liu_outliers(
     "--max_unique_values",
     help=(
         "Upper bound on unique values per column for the Rule-of-N filter "
-        "(default 9). Only applies when no saved vectorizer is present."
+        "(default 9). Only applies when no saved vectorizer is present; "
+        "when a saved vectorizer exists the Rule-of-N filter is bypassed "
+        "entirely so the training-fitted vectorizer is the authoritative "
+        "source of truth on kept columns."
     ),
     type=int,
     default=None,
@@ -1039,6 +1063,13 @@ def generate(
         max_unique_values if max_unique_values is not None else DEFAULT_MAX_UNIQUE_VALUES
     )
 
+    # Load the training-fitted vectorizer *before* constructing the
+    # DataLoader so that we can disable the Rule-of-N filter when a
+    # saved vectorizer is present (Codex P1 PR#49). See ``evaluate`` for
+    # the full rationale.
+    saved_vectorizer = load_vectorizer(model_path)
+    apply_rule_of_n = saved_vectorizer is None
+
     logger.info("Loading data....")
     data_loader = DataLoader(
         drop_columns,
@@ -1048,12 +1079,12 @@ def generate(
         additional_rename_columns=additional_rename_columns,
         additional_columns_of_interest=additional_interest_columns,
         max_unique_values=effective_max_unique,
+        apply_rule_of_n=apply_rule_of_n,
     )
     project_data, metadata = data_loader.load_data(data)
     variable_types = metadata.get("variable_types", {})
 
     logger.info("Creating the vectorizer....")
-    saved_vectorizer = load_vectorizer(model_path)
     if saved_vectorizer is not None:
         project_data = _clean_for_saved_vectorizer(project_data, saved_vectorizer)
         vectorized_df = saved_vectorizer.transform(project_data).astype("float32")

--- a/main.py
+++ b/main.py
@@ -59,6 +59,48 @@ logger.setLevel(logging.DEBUG)
 logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
+def _coerce_max_unique_values(value):
+    """Normalize a user-supplied ``max_unique_values`` at config-ingestion
+    boundaries (YAML files, CLI flags).
+
+    - ``None`` (unset CLI flag, or ``max_unique_values: null`` in the
+      YAML — common in templated configs) coerces to the built-in
+      default instead of propagating downstream. Without this, a
+      ``None`` would reach ``prepare_for_categorical`` and crash on
+      ``None < 2`` with a confusing ``TypeError`` before data
+      processing even starts (Codex P2 PR#49).
+    - Non-integer values (e.g. a string "9" from an env-var leak into
+      the YAML loader, or a float like ``9.0``) are cast to ``int``.
+      Anything that can't be cast raises ``ValueError``.
+    - Integers below 2 raise ``ValueError`` — a threshold below 2 would
+      drop every column because the Rule-of-N filter also rejects
+      ``n_unique <= 1``.
+
+    Args:
+        value: The raw value from a CLI flag or YAML config.
+
+    Returns:
+        int: A validated ``max_unique_values`` suitable for passing
+        into ``DataLoader`` / ``prepare_for_*`` helpers.
+
+    Raises:
+        ValueError: If ``value`` is non-None but not a valid threshold.
+    """
+    if value is None:
+        return DEFAULT_MAX_UNIQUE_VALUES
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError) as e:
+        raise ValueError(
+            f"max_unique_values must be an integer (got {value!r})"
+        ) from e
+    if coerced < 2:
+        raise ValueError(
+            f"max_unique_values must be >= 2 (got {coerced})"
+        )
+    return coerced
+
+
 def prepare_for_categorical(project_data, max_unique_values=DEFAULT_MAX_UNIQUE_VALUES):
     """Clean data for categorical-only models (Chow-Liu tree, etc.).
 
@@ -340,7 +382,8 @@ def run_training_pipeline(df, config_path, output_path, model_name="AE", prior="
 
     The optional ``max_unique_values`` YAML key in the config file
     overrides the default Rule-of-N threshold for data cleaning
-    (TASKS.md 3.1).
+    (TASKS.md 3.1). An explicit ``null`` in the YAML is coerced to
+    the default via ``_coerce_max_unique_values``.
     """
     logger.info(f"loading config from {config_path}...")
     with open(config_path, "r") as file:
@@ -349,7 +392,9 @@ def run_training_pipeline(df, config_path, output_path, model_name="AE", prior="
     _, X_train, X_test, vectorizer, cardinalities = prepare_for_training(
         df,
         test_size=config.get("test_size", 0.2),
-        max_unique_values=config.get("max_unique_values", DEFAULT_MAX_UNIQUE_VALUES),
+        max_unique_values=_coerce_max_unique_values(
+            config.get("max_unique_values")
+        ),
     )
 
     model = get_model(model_name, cardinalities)
@@ -445,11 +490,12 @@ def train(
         config_dict = yaml.safe_load(file)
 
     # CLI flag takes precedence over the YAML key, which takes precedence
-    # over the built-in default.
+    # over the built-in default. Both routes go through
+    # ``_coerce_max_unique_values`` so ``null`` in a templated YAML
+    # config doesn't crash downstream with ``None < 2`` (Codex P2 PR#49).
     if max_unique_values is None:
-        max_unique_values = config_dict.get(
-            "max_unique_values", DEFAULT_MAX_UNIQUE_VALUES
-        )
+        max_unique_values = config_dict.get("max_unique_values")
+    max_unique_values = _coerce_max_unique_values(max_unique_values)
 
     # 3. Initialize Loader
     logger.info("Loading data....")
@@ -561,10 +607,12 @@ def search_hyperparameters(
     with open(config, "r") as file:
         config = yaml.safe_load(file)
 
+    # CLI flag > YAML key > built-in default, coerced through
+    # ``_coerce_max_unique_values`` so ``null`` in a templated YAML
+    # doesn't crash downstream (Codex P2 PR#49).
     if max_unique_values is None:
-        max_unique_values = config.get(
-            "max_unique_values", DEFAULT_MAX_UNIQUE_VALUES
-        )
+        max_unique_values = config.get("max_unique_values")
+    max_unique_values = _coerce_max_unique_values(max_unique_values)
 
     data_loader = DataLoader(
         drop_columns,
@@ -652,9 +700,7 @@ def evaluate(
         additional_interest_columns,
     ) = define_necessary_elements(data, drop_columns, rename_columns, interest_columns)
 
-    effective_max_unique = (
-        max_unique_values if max_unique_values is not None else DEFAULT_MAX_UNIQUE_VALUES
-    )
+    effective_max_unique = _coerce_max_unique_values(max_unique_values)
 
     set_seed(seed)
 
@@ -783,9 +829,7 @@ def find_outliers(
         additional_interest_columns,
     ) = define_necessary_elements(data, drop_columns, rename_columns, interest_columns)
 
-    effective_max_unique = (
-        max_unique_values if max_unique_values is not None else DEFAULT_MAX_UNIQUE_VALUES
-    )
+    effective_max_unique = _coerce_max_unique_values(max_unique_values)
 
     # Load the training-fitted vectorizer *before* constructing the
     # DataLoader so that we can disable the Rule-of-N filter when a
@@ -925,9 +969,7 @@ def chow_liu_outliers(
         additional_interest_columns,
     ) = define_necessary_elements(data, drop_columns, rename_columns, interest_columns)
 
-    effective_max_unique = (
-        max_unique_values if max_unique_values is not None else DEFAULT_MAX_UNIQUE_VALUES
-    )
+    effective_max_unique = _coerce_max_unique_values(max_unique_values)
 
     # 2. Initialize Loader
     logger.info("Loading data...")
@@ -1059,9 +1101,7 @@ def generate(
         additional_interest_columns,
     ) = define_necessary_elements(data, drop_columns, rename_columns, interest_columns)
 
-    effective_max_unique = (
-        max_unique_values if max_unique_values is not None else DEFAULT_MAX_UNIQUE_VALUES
-    )
+    effective_max_unique = _coerce_max_unique_values(max_unique_values)
 
     # Load the training-fitted vectorizer *before* constructing the
     # DataLoader so that we can disable the Rule-of-N filter when a
@@ -1269,9 +1309,7 @@ def pca_baseline(
         additional_interest_columns,
     ) = define_necessary_elements(data, drop_columns, rename_columns, interest_columns)
 
-    effective_max_unique = (
-        max_unique_values if max_unique_values is not None else DEFAULT_MAX_UNIQUE_VALUES
-    )
+    effective_max_unique = _coerce_max_unique_values(max_unique_values)
 
     data_loader = DataLoader(
         drop_columns,

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ import pandas as pd
 import yaml
 from sklearn.model_selection import train_test_split
 
-from dataset.loader import DataLoader
+from dataset.loader import DataLoader, DEFAULT_MAX_UNIQUE_VALUES
 from evaluate.evaluator import Evaluator
 from evaluate.generator import Generator
 from evaluate.outliers import get_outliers_list
@@ -59,25 +59,34 @@ logger.setLevel(logging.DEBUG)
 logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
-def prepare_for_categorical(project_data):
+def prepare_for_categorical(project_data, max_unique_values=DEFAULT_MAX_UNIQUE_VALUES):
     """Clean data for categorical-only models (Chow-Liu tree, etc.).
 
     Steps:
         1. Fill NaN with "missing" and cast to string
-        2. Apply Rule-of-9 filter (keep columns with 2-9 unique values)
+        2. Apply Rule-of-N filter (keep columns with 2..max_unique_values
+           unique values).
 
     Args:
         project_data: Raw DataFrame from DataLoader.
+        max_unique_values: Upper bound on the number of unique values a
+            column may have and still be kept. Defaults to
+            ``DEFAULT_MAX_UNIQUE_VALUES`` (9). Must be >= 2.
 
     Returns:
         cleaned_df: DataFrame with only low-cardinality categorical columns.
     """
+    if max_unique_values < 2:
+        raise ValueError(
+            f"max_unique_values must be >= 2 (got {max_unique_values})"
+        )
+
     project_data = project_data.fillna("missing")
     project_data = project_data.astype(str)
 
     cols_to_keep = [
         col for col in project_data.columns
-        if 1 < project_data[col].nunique() <= 9
+        if 1 < project_data[col].nunique() <= max_unique_values
     ]
     return project_data[cols_to_keep]
 
@@ -136,11 +145,21 @@ def _clean_for_saved_vectorizer(project_data, vectorizer):
     return project_data[trained_cols]
 
 
-def _clean_and_build_vectorizer(project_data, variable_types=None):
+def _clean_and_build_vectorizer(
+    project_data,
+    variable_types=None,
+    max_unique_values=DEFAULT_MAX_UNIQUE_VALUES,
+):
     """Clean data and create a (not-yet-fitted) Table2Vector.
 
     Shared first step for both ``prepare_for_model`` and
     ``prepare_for_training``.
+
+    Args:
+        project_data: Raw DataFrame from DataLoader.
+        variable_types: Optional dict mapping column names to types.
+        max_unique_values: Upper bound on the number of unique values a
+            column may have and still be kept (Rule-of-N threshold).
 
     Returns:
         (cleaned_df, variable_types_dict, vectorizer)
@@ -148,8 +167,10 @@ def _clean_and_build_vectorizer(project_data, variable_types=None):
     if variable_types is None:
         variable_types = {}
 
-    # 1-2. Clean data (fillna, Rule-of-9)
-    project_data = prepare_for_categorical(project_data)
+    # 1-2. Clean data (fillna, Rule-of-N)
+    project_data = prepare_for_categorical(
+        project_data, max_unique_values=max_unique_values
+    )
 
     # 3. Sync variable_types to surviving columns
     variable_types = {c: variable_types.get(c, "categorical") for c in project_data.columns}
@@ -212,7 +233,11 @@ def _compute_attr_layout(vectorizer, cleaned_columns):
     return attr_cardinalities, attr_is_categorical
 
 
-def prepare_for_model(project_data, variable_types=None):
+def prepare_for_model(
+    project_data,
+    variable_types=None,
+    max_unique_values=DEFAULT_MAX_UNIQUE_VALUES,
+):
     """Shared data-cleaning and vectorization pipeline.
 
     Use this for **scoring / evaluation** where the entire dataset is
@@ -223,7 +248,7 @@ def prepare_for_model(project_data, variable_types=None):
 
     Steps:
         1. Fill NaN with "missing" and cast to string
-        2. Apply Rule-of-9 filter (keep columns with 2-9 unique values)
+        2. Apply Rule-of-N filter (keep columns with 2..N unique values)
         3. Sync variable_types to surviving columns
         4. Vectorize via Table2Vector (one-hot encoding)
         5. Convert to float32
@@ -233,12 +258,14 @@ def prepare_for_model(project_data, variable_types=None):
         project_data: Raw DataFrame from DataLoader.
         variable_types: Optional dict mapping column names to types.
             If None or empty, all columns are treated as categorical.
+        max_unique_values: Upper bound on the number of unique values a
+            column may have and still be kept (Rule-of-N threshold).
 
     Returns:
         (cleaned_df, vectorized_df, vectorizer, cardinalities)
     """
     project_data, _, vectorizer = _clean_and_build_vectorizer(
-        project_data, variable_types
+        project_data, variable_types, max_unique_values=max_unique_values
     )
 
     # 4. Vectorize (fit + transform on the full data — acceptable for
@@ -254,7 +281,12 @@ def prepare_for_model(project_data, variable_types=None):
     return project_data, vectorized_df, vectorizer, cardinalities
 
 
-def prepare_for_training(project_data, variable_types=None, test_size=0.2):
+def prepare_for_training(
+    project_data,
+    variable_types=None,
+    test_size=0.2,
+    max_unique_values=DEFAULT_MAX_UNIQUE_VALUES,
+):
     """Clean, split, then vectorize — preventing data leakage.
 
     Unlike :func:`prepare_for_model`, the vectorizer is fitted on the
@@ -273,12 +305,14 @@ def prepare_for_training(project_data, variable_types=None, test_size=0.2):
         project_data: Raw DataFrame from DataLoader.
         variable_types: Optional dict mapping column names to types.
         test_size: Fraction of data for the test set (default 0.2).
+        max_unique_values: Upper bound on the number of unique values a
+            column may have and still be kept (Rule-of-N threshold).
 
     Returns:
         (cleaned_df, X_train, X_test, vectorizer, cardinalities)
     """
     project_data, _, vectorizer = _clean_and_build_vectorizer(
-        project_data, variable_types
+        project_data, variable_types, max_unique_values=max_unique_values
     )
 
     # 4. Split *before* vectorization
@@ -302,14 +336,20 @@ def prepare_for_training(project_data, variable_types=None, test_size=0.2):
 def run_training_pipeline(df, config_path, output_path, model_name="AE", prior="gaussian"):
     """
     Reusable training logic that accepts a DataFrame directly.
-    Used by both the CLI and the Cloud Worker
+    Used by both the CLI and the Cloud Worker.
+
+    The optional ``max_unique_values`` YAML key in the config file
+    overrides the default Rule-of-N threshold for data cleaning
+    (TASKS.md 3.1).
     """
     logger.info(f"loading config from {config_path}...")
     with open(config_path, "r") as file:
         config = yaml.safe_load(file)
 
     _, X_train, X_test, vectorizer, cardinalities = prepare_for_training(
-        df, test_size=config.get("test_size", 0.2)
+        df,
+        test_size=config.get("test_size", 0.2),
+        max_unique_values=config.get("max_unique_values", DEFAULT_MAX_UNIQUE_VALUES),
     )
 
     model = get_model(model_name, cardinalities)
@@ -360,6 +400,16 @@ def cli():
     type=str,
     default="cache/simple_model/",
 )
+@click.option(
+    "--max_unique_values",
+    help=(
+        "Upper bound on unique values per column for the Rule-of-N filter "
+        "(default 9). Columns with <= 1 or > this many unique values are "
+        "dropped. Overrides any ``max_unique_values`` key in the YAML config."
+    ),
+    type=int,
+    default=None,
+)
 def train(
     seed,
     model_name,
@@ -370,13 +420,14 @@ def train(
     interest_columns,
     config,
     output,
+    max_unique_values,
 ):
     logger.debug("Starting train function")
-    
+
     # 1. Set Seed
     set_seed(seed)
 
-    
+
 
     # 2. Parse Column Arguments (Safe Split)
     (
@@ -388,6 +439,18 @@ def train(
         additional_interest_columns,
     ) = define_necessary_elements(data, drop_columns, rename_columns, interest_columns)
 
+    # 5. Clean, split, vectorize (leak-free)
+    logger.info("Transforming the data....")
+    with open(config, "r") as file:
+        config_dict = yaml.safe_load(file)
+
+    # CLI flag takes precedence over the YAML key, which takes precedence
+    # over the built-in default.
+    if max_unique_values is None:
+        max_unique_values = config_dict.get(
+            "max_unique_values", DEFAULT_MAX_UNIQUE_VALUES
+        )
+
     # 3. Initialize Loader
     logger.info("Loading data....")
     data_loader = DataLoader(
@@ -397,20 +460,17 @@ def train(
         additional_drop_columns=additional_drop_columns,
         additional_rename_columns=additional_rename_columns,
         additional_columns_of_interest=additional_interest_columns,
+        max_unique_values=max_unique_values,
     )
-    
+
     # 4. Load data -- all loaders return (DataFrame, metadata_dict)
     project_data, metadata = data_loader.load_data(data)
     variable_types = metadata.get("variable_types", {})
 
-    # 5. Clean, split, vectorize (leak-free)
-    logger.info("Transforming the data....")
-    with open(config, "r") as file:
-        config_dict = yaml.safe_load(file)
-
     project_data, X_train, X_test, vectorizer, cardinalities = prepare_for_training(
         project_data, variable_types,
         test_size=config_dict.get("test_size", 0.2),
+        max_unique_values=max_unique_values,
     )
 
     # 6. Build and Train model
@@ -464,6 +524,15 @@ def train(
     type=str,
     default="cache/simple_model/",
 )
+@click.option(
+    "--max_unique_values",
+    help=(
+        "Upper bound on unique values per column for the Rule-of-N filter "
+        "(default 9). Overrides any ``max_unique_values`` key in the YAML config."
+    ),
+    type=int,
+    default=None,
+)
 def search_hyperparameters(
     seed,
     model_name,
@@ -474,6 +543,7 @@ def search_hyperparameters(
     interest_columns,
     config,
     output,
+    max_unique_values,
 ):
 
     set_seed(seed)
@@ -487,6 +557,15 @@ def search_hyperparameters(
         additional_interest_columns,
     ) = define_necessary_elements(data, drop_columns, rename_columns, interest_columns)
 
+    logger.info("Loading config from config file....")
+    with open(config, "r") as file:
+        config = yaml.safe_load(file)
+
+    if max_unique_values is None:
+        max_unique_values = config.get(
+            "max_unique_values", DEFAULT_MAX_UNIQUE_VALUES
+        )
+
     data_loader = DataLoader(
         drop_columns,
         rename_columns,
@@ -494,18 +573,16 @@ def search_hyperparameters(
         additional_drop_columns=additional_drop_columns,
         additional_rename_columns=additional_rename_columns,
         additional_columns_of_interest=additional_interest_columns,
+        max_unique_values=max_unique_values,
     )
     project_data, metadata = data_loader.load_data(data)
     variable_types = metadata.get("variable_types", {})
-
-    logger.info("Loading config from config file....")
-    with open(config, "r") as file:
-        config = yaml.safe_load(file)
 
     logger.info("Transforming the data....")
     project_data, X_train, X_test, vectorizer, cardinalities = prepare_for_training(
         project_data, variable_types,
         test_size=config.get("test_size", 0.2),
+        max_unique_values=max_unique_values,
     )
 
     logger.info("Loading model....")
@@ -549,8 +626,19 @@ def search_hyperparameters(
     type=str,
     default="cache/predictions/",
 )
+@click.option(
+    "--max_unique_values",
+    help=(
+        "Upper bound on unique values per column for the Rule-of-N filter "
+        "(default 9). Only applies when no saved vectorizer is present; "
+        "otherwise the training-fitted vectorizer dictates kept columns."
+    ),
+    type=int,
+    default=None,
+)
 def evaluate(
-    seed, model_path, data, drop_columns, rename_columns, interest_columns, output
+    seed, model_path, data, drop_columns, rename_columns, interest_columns, output,
+    max_unique_values,
 ):
 
     (
@@ -562,6 +650,10 @@ def evaluate(
         additional_interest_columns,
     ) = define_necessary_elements(data, drop_columns, rename_columns, interest_columns)
 
+    effective_max_unique = (
+        max_unique_values if max_unique_values is not None else DEFAULT_MAX_UNIQUE_VALUES
+    )
+
     data_loader = DataLoader(
         drop_columns,
         rename_columns,
@@ -569,6 +661,7 @@ def evaluate(
         additional_drop_columns=additional_drop_columns,
         additional_rename_columns=additional_rename_columns,
         additional_columns_of_interest=additional_interest_columns,
+        max_unique_values=effective_max_unique,
     )
 
     set_seed(seed)
@@ -589,7 +682,8 @@ def evaluate(
         vectorizer = saved_vectorizer
     else:
         project_data, vectorized_df, vectorizer, _ = prepare_for_model(
-            project_data, variable_types
+            project_data, variable_types,
+            max_unique_values=effective_max_unique,
         )
     variable_types = {c: "categorical" for c in project_data.columns}
 
@@ -640,6 +734,16 @@ def evaluate(
     type=str,
     default="cache/predictions/",
 )
+@click.option(
+    "--max_unique_values",
+    help=(
+        "Upper bound on unique values per column for the Rule-of-N filter "
+        "(default 9). Only applies when no saved vectorizer is present; "
+        "otherwise the training-fitted vectorizer dictates kept columns."
+    ),
+    type=int,
+    default=None,
+)
 def find_outliers(
     seed,
     model_path,
@@ -650,11 +754,12 @@ def find_outliers(
     interest_columns,
     k,
     output,
+    max_unique_values,
 ):
     logger.debug("Starting find_outliers")
     set_seed(seed)
 
-    # 1. Parse Column Arguments 
+    # 1. Parse Column Arguments
     (
         drop_columns,
         rename_columns,
@@ -663,6 +768,10 @@ def find_outliers(
         additional_rename_columns,
         additional_interest_columns,
     ) = define_necessary_elements(data, drop_columns, rename_columns, interest_columns)
+
+    effective_max_unique = (
+        max_unique_values if max_unique_values is not None else DEFAULT_MAX_UNIQUE_VALUES
+    )
 
     # 2. Initialize Loader
     logger.info("Loading data...")
@@ -673,6 +782,7 @@ def find_outliers(
         additional_drop_columns=additional_drop_columns,
         additional_rename_columns=additional_rename_columns,
         additional_columns_of_interest=additional_interest_columns,
+        max_unique_values=effective_max_unique,
     )
 
     # 3. Load data -- all loaders return (DataFrame, metadata_dict)
@@ -688,7 +798,8 @@ def find_outliers(
         vectorizer = saved_vectorizer
     else:
         project_data, vectorized_df, vectorizer, _ = prepare_for_model(
-            project_data, variable_types
+            project_data, variable_types,
+            max_unique_values=effective_max_unique,
         )
 
     # Derive attr_cardinalities and attr_is_categorical in the actual
@@ -754,6 +865,15 @@ def find_outliers(
     type=str,
     default="cache/predictions/",
 )
+@click.option(
+    "--max_unique_values",
+    help=(
+        "Upper bound on unique values per column for the Rule-of-N filter "
+        "(default 9)."
+    ),
+    type=int,
+    default=None,
+)
 def chow_liu_outliers(
     seed,
     data,
@@ -763,6 +883,7 @@ def chow_liu_outliers(
     alpha,
     mi_subsample,
     output,
+    max_unique_values,
 ):
     """Detect outliers using Chow-Liu tree log-likelihood scoring.
 
@@ -783,6 +904,10 @@ def chow_liu_outliers(
         additional_interest_columns,
     ) = define_necessary_elements(data, drop_columns, rename_columns, interest_columns)
 
+    effective_max_unique = (
+        max_unique_values if max_unique_values is not None else DEFAULT_MAX_UNIQUE_VALUES
+    )
+
     # 2. Initialize Loader
     logger.info("Loading data...")
     data_loader = DataLoader(
@@ -792,19 +917,24 @@ def chow_liu_outliers(
         additional_drop_columns=additional_drop_columns,
         additional_rename_columns=additional_rename_columns,
         additional_columns_of_interest=additional_interest_columns,
+        max_unique_values=effective_max_unique,
     )
 
     # 3. Load data
     project_data, metadata = data_loader.load_data(data)
 
-    # 4. Clean data (fillna + Rule-of-9, no vectorization needed)
+    # 4. Clean data (fillna + Rule-of-N, no vectorization needed)
     logger.info("Cleaning the data...")
-    cleaned_df = prepare_for_categorical(project_data)
+    cleaned_df = prepare_for_categorical(
+        project_data, max_unique_values=effective_max_unique
+    )
     logger.info(f"Cleaned data: {cleaned_df.shape[0]} rows, {cleaned_df.shape[1]} columns")
 
     if cleaned_df.shape[1] == 0:
         logger.error(
-            "No columns survived cleaning (Rule-of-9). Cannot fit Chow-Liu tree."
+            "No columns survived cleaning (Rule-of-N, N=%d). Cannot fit "
+            "Chow-Liu tree.",
+            effective_max_unique,
         )
         return
 
@@ -864,6 +994,15 @@ def chow_liu_outliers(
     type=str,
     default=None,
 )
+@click.option(
+    "--max_unique_values",
+    help=(
+        "Upper bound on unique values per column for the Rule-of-N filter "
+        "(default 9). Only applies when no saved vectorizer is present."
+    ),
+    type=int,
+    default=None,
+)
 def generate(
     seed,
     prior,
@@ -875,6 +1014,7 @@ def generate(
     rename_columns,
     interest_columns,
     target_features,
+    max_unique_values,
 ):
 
     set_seed(seed)
@@ -895,6 +1035,10 @@ def generate(
         additional_interest_columns,
     ) = define_necessary_elements(data, drop_columns, rename_columns, interest_columns)
 
+    effective_max_unique = (
+        max_unique_values if max_unique_values is not None else DEFAULT_MAX_UNIQUE_VALUES
+    )
+
     logger.info("Loading data....")
     data_loader = DataLoader(
         drop_columns,
@@ -903,6 +1047,7 @@ def generate(
         additional_drop_columns=additional_drop_columns,
         additional_rename_columns=additional_rename_columns,
         additional_columns_of_interest=additional_interest_columns,
+        max_unique_values=effective_max_unique,
     )
     project_data, metadata = data_loader.load_data(data)
     variable_types = metadata.get("variable_types", {})
@@ -916,7 +1061,8 @@ def generate(
         attr_cardinalities = saved_vectorizer.get_cardinalities(project_data.columns)
     else:
         project_data, vectorized_df, vectorizer, attr_cardinalities = prepare_for_model(
-            project_data, variable_types
+            project_data, variable_types,
+            max_unique_values=effective_max_unique,
         )
 
     if target_features is not None:
@@ -1061,6 +1207,15 @@ def evaluate_on_condition(
 @click.option(
     "--outlier_value", help="outlier_value of the column", type=str, default=None
 )
+@click.option(
+    "--max_unique_values",
+    help=(
+        "Upper bound on unique values per column for the Rule-of-N filter "
+        "(default 9)."
+    ),
+    type=int,
+    default=None,
+)
 def pca_baseline(
     seed,
     data,
@@ -1069,6 +1224,7 @@ def pca_baseline(
     interest_columns,
     column_to_condition,
     outlier_value,
+    max_unique_values,
 ):
 
     set_seed(seed)
@@ -1082,6 +1238,10 @@ def pca_baseline(
         additional_interest_columns,
     ) = define_necessary_elements(data, drop_columns, rename_columns, interest_columns)
 
+    effective_max_unique = (
+        max_unique_values if max_unique_values is not None else DEFAULT_MAX_UNIQUE_VALUES
+    )
+
     data_loader = DataLoader(
         drop_columns,
         rename_columns,
@@ -1089,6 +1249,7 @@ def pca_baseline(
         additional_drop_columns=additional_drop_columns,
         additional_rename_columns=additional_rename_columns,
         additional_columns_of_interest=additional_interest_columns,
+        max_unique_values=effective_max_unique,
     )
 
     if column_to_condition is None or outlier_value is None:
@@ -1115,7 +1276,8 @@ def pca_baseline(
 
     logger.info("Transforming the data....")
     project_data, vectorized_df, vectorizer, _ = prepare_for_model(
-        project_data, variable_types
+        project_data, variable_types,
+        max_unique_values=effective_max_unique,
     )
     variable_types = {c: "categorical" for c in project_data.columns}
 

--- a/tests/test_rule_of_n.py
+++ b/tests/test_rule_of_n.py
@@ -447,11 +447,12 @@ class TestVertexContainerArgPropagation(unittest.TestCase):
     def test_worker_forwards_env_var_to_vertex(self):
         """End-to-end: when the operator sets MAX_UNIQUE_VALUES=20 on
         the worker, the helper that builds the Vertex CLI args picks
-        it up via ``_resolve_max_unique_values`` (the same function
-        used by the local path) so both modes stay in sync."""
+        it up via ``_resolve_explicit_max_unique_values`` (the same
+        function ``process_upload_vertex`` now uses) so both modes
+        stay in sync."""
         from worker import (
             _build_vertex_training_args,
-            _resolve_max_unique_values,
+            _resolve_explicit_max_unique_values,
         )
 
         with mock.patch.dict(os.environ, {"MAX_UNIQUE_VALUES": "20"}):
@@ -459,9 +460,109 @@ class TestVertexContainerArgPropagation(unittest.TestCase):
                 "j",
                 "b",
                 "f",
-                max_unique_values=_resolve_max_unique_values(),
+                max_unique_values=_resolve_explicit_max_unique_values(),
             )
         self.assertIn("--max-unique-values=20", args)
+
+    def test_worker_omits_flag_when_env_var_unset(self):
+        """Rolling-deploy safety: when the operator has NOT set
+        ``MAX_UNIQUE_VALUES``, the Vertex dispatcher must omit the
+        ``--max-unique-values`` flag entirely so a container running an
+        older ``train/task.py`` (which doesn't recognise the flag)
+        still parses the arg list cleanly (Codex P1 PR#49).
+
+        This is the scenario the first fix attempt missed:
+        ``_resolve_max_unique_values()`` always returns 9 when the env
+        var is unset, which would always append the flag and defeat
+        the backwards-compat path in ``_build_vertex_training_args``.
+        ``_resolve_explicit_max_unique_values()`` returns ``None`` in
+        that case, so the flag is correctly omitted.
+        """
+        from worker import (
+            _build_vertex_training_args,
+            _resolve_explicit_max_unique_values,
+        )
+
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MAX_UNIQUE_VALUES", None)
+            resolved = _resolve_explicit_max_unique_values()
+            args = _build_vertex_training_args(
+                "j",
+                "b",
+                "f",
+                max_unique_values=resolved,
+            )
+        self.assertIsNone(resolved)
+        self.assertNotIn(
+            "--max-unique-values",
+            " ".join(args),
+            f"expected flag to be omitted; got {args}",
+        )
+        self.assertEqual(
+            args,
+            [
+                "--job-id=j",
+                "--bucket-name=b",
+                "--file-path=f",
+            ],
+        )
+
+    def test_worker_omits_flag_when_env_var_invalid(self):
+        """Same as ``test_worker_omits_flag_when_env_var_unset`` for
+        invalid values (non-integer, below 2): the resolver returns
+        ``None`` and the dispatcher omits the flag, preserving rolling
+        deploy compatibility."""
+        from worker import _resolve_explicit_max_unique_values
+
+        for bad in ("", "abc", "9.5", "0", "1", "-3"):
+            with mock.patch.dict(os.environ, {"MAX_UNIQUE_VALUES": bad}):
+                self.assertIsNone(
+                    _resolve_explicit_max_unique_values(),
+                    f"bad value {bad!r} should resolve to None",
+                )
+
+    def test_explicit_resolver_returns_valid_int(self):
+        """Happy path: valid env var → parsed int, not ``None``."""
+        from worker import _resolve_explicit_max_unique_values
+
+        with mock.patch.dict(os.environ, {"MAX_UNIQUE_VALUES": "15"}):
+            self.assertEqual(_resolve_explicit_max_unique_values(), 15)
+
+    def test_process_upload_vertex_uses_explicit_resolver(self):
+        """Drift guard: read ``worker.py`` as source and verify
+        ``process_upload_vertex`` references
+        ``_resolve_explicit_max_unique_values`` (not
+        ``_resolve_max_unique_values``) when building Vertex args.
+        If a future change regresses back to the non-explicit
+        resolver, the flag will always be appended and rolling
+        deploys break — this test catches that before CI / prod."""
+        import pathlib
+
+        source_path = pathlib.Path(__file__).resolve().parents[1] / "worker.py"
+        source = source_path.read_text()
+
+        # Locate the process_upload_vertex function body and check
+        # which resolver it passes into _build_vertex_training_args.
+        start = source.index("def process_upload_vertex(")
+        # Rough body end: the next top-level ``def `` declaration or
+        # end-of-file — good enough for a drift guard.
+        next_def = source.find("\ndef ", start + 1)
+        body = source[start:next_def] if next_def != -1 else source[start:]
+
+        self.assertIn("_build_vertex_training_args", body)
+        self.assertIn("_resolve_explicit_max_unique_values", body)
+        # Make sure the non-explicit resolver is NOT what we pass into
+        # _build_vertex_training_args. It may still appear in other
+        # contexts (e.g. logging), so look at the
+        # ``max_unique_values=`` keyword argument line specifically.
+        for line in body.splitlines():
+            if "max_unique_values=" in line and "_resolve_max_unique_values" in line:
+                self.fail(
+                    f"process_upload_vertex uses the non-explicit "
+                    f"resolver, which always returns an int and "
+                    f"defeats the rolling-deploy compat path: "
+                    f"{line.strip()!r}"
+                )
 
     def test_train_task_cli_accepts_max_unique_values(self):
         """``train/task.py``'s argparse must accept the new flag so

--- a/tests/test_rule_of_n.py
+++ b/tests/test_rule_of_n.py
@@ -38,6 +38,7 @@ from dataset.loader import DEFAULT_MAX_UNIQUE_VALUES, DataLoader
 from features.transform import Table2Vector
 from main import (
     _clean_for_saved_vectorizer,
+    _coerce_max_unique_values,
     prepare_for_categorical,
     prepare_for_model,
     prepare_for_training,
@@ -386,6 +387,98 @@ class TestApplyRuleOfNFlag(unittest.TestCase):
                 all(isinstance(v, str) for v in clean_df[col]),
                 f"column {col!r} contains non-string values",
             )
+
+
+class TestCoerceMaxUniqueValues(unittest.TestCase):
+    """``main._coerce_max_unique_values`` normalizes user-supplied
+    threshold values at config-ingestion boundaries (CLI flag, YAML
+    config). The crash Codex P2 flagged was: ``max_unique_values: null``
+    in a templated YAML returns ``None`` from ``.get()``, and the
+    downstream ``prepare_for_categorical`` path does
+    ``max_unique_values < 2`` which raises ``TypeError`` in Python 3
+    because ``None < 2`` is not orderable — before any data is even
+    touched.
+    """
+
+    def test_none_coerces_to_default(self):
+        """YAML ``null`` → default. This is the Codex P2 scenario."""
+        self.assertEqual(
+            _coerce_max_unique_values(None), DEFAULT_MAX_UNIQUE_VALUES
+        )
+
+    def test_int_passes_through(self):
+        self.assertEqual(_coerce_max_unique_values(15), 15)
+        self.assertEqual(_coerce_max_unique_values(2), 2)
+        self.assertEqual(_coerce_max_unique_values(9), 9)
+
+    def test_numeric_string_is_coerced(self):
+        """YAML loaders occasionally surface numeric strings (for
+        example when env-var interpolation is on). Accept and coerce."""
+        self.assertEqual(_coerce_max_unique_values("15"), 15)
+
+    def test_float_is_coerced_to_int(self):
+        """``9.0`` from a YAML ``!!float 9`` tag is valid."""
+        self.assertEqual(_coerce_max_unique_values(9.0), 9)
+
+    def test_below_two_raises(self):
+        for value in (1, 0, -3):
+            with self.assertRaises(ValueError):
+                _coerce_max_unique_values(value)
+
+    def test_non_integer_raises(self):
+        for value in ("abc", "9.5", [], {}):
+            with self.assertRaises(ValueError):
+                _coerce_max_unique_values(value)
+
+    def test_returns_int_even_when_passed_int_subclass(self):
+        """Sanity check: bool is an int subclass, but any int >= 2 is
+        accepted. Document the behaviour so no one is surprised."""
+        # True == 1 which is < 2, so True should raise.
+        with self.assertRaises(ValueError):
+            _coerce_max_unique_values(True)
+
+    def test_yaml_null_end_to_end_through_run_training_pipeline_config(self):
+        """Regression for Codex P2 PR#49: the YAML ingestion boundary
+        must translate ``max_unique_values: null`` to the default
+        before handing it to ``prepare_for_training``. This test
+        simulates the YAML-read step without actually invoking the
+        training pipeline (which would need TF), by asserting that a
+        parsed YAML dict with an explicit ``None`` roundtrips through
+        ``_coerce_max_unique_values`` to the default.
+        """
+        import yaml
+
+        yaml_text = """
+        test_size: 0.2
+        max_unique_values: null
+        """
+        config = yaml.safe_load(yaml_text)
+        self.assertIsNone(config["max_unique_values"])
+
+        coerced = _coerce_max_unique_values(config.get("max_unique_values"))
+        self.assertEqual(coerced, DEFAULT_MAX_UNIQUE_VALUES)
+
+    def test_yaml_missing_key_end_to_end(self):
+        """If the key is absent from the YAML entirely, ``.get()``
+        returns ``None``, which also coerces to the default."""
+        import yaml
+
+        yaml_text = "test_size: 0.2\n"
+        config = yaml.safe_load(yaml_text)
+        self.assertNotIn("max_unique_values", config)
+
+        coerced = _coerce_max_unique_values(config.get("max_unique_values"))
+        self.assertEqual(coerced, DEFAULT_MAX_UNIQUE_VALUES)
+
+    def test_yaml_explicit_value_is_honoured(self):
+        import yaml
+
+        yaml_text = "max_unique_values: 15\n"
+        config = yaml.safe_load(yaml_text)
+        self.assertEqual(
+            _coerce_max_unique_values(config.get("max_unique_values")),
+            15,
+        )
 
 
 class TestVertexContainerArgPropagation(unittest.TestCase):

--- a/tests/test_rule_of_n.py
+++ b/tests/test_rule_of_n.py
@@ -1,0 +1,297 @@
+"""Tests for the configurable "Rule of N" cardinality threshold
+(TASKS.md 3.1).
+
+Previously the max-unique-values threshold for dropping columns was
+hardcoded to 9 in several places:
+
+- ``DataLoader.prepare_original_dataset`` in ``dataset/loader.py``
+- ``prepare_for_categorical`` in ``main.py`` (plus its transitive
+  callers ``prepare_for_model`` and ``prepare_for_training``)
+- Inline Rule-of-9 loops in ``worker.py`` and ``train/task.py``
+
+These tests verify that the threshold is now configurable end-to-end:
+
+- ``DataLoader`` honours the ``max_unique_values`` constructor argument
+  on every loader entry point that calls ``prepare_original_dataset``
+  (including the uploaded-CSV path via ``load_uploaded_csv``).
+- ``DataLoader.prepare_original_dataset`` accepts a per-call override.
+- ``main.prepare_for_categorical`` / ``prepare_for_model`` /
+  ``prepare_for_training`` all plumb the parameter through correctly.
+- ``worker._resolve_max_unique_values`` reads the ``MAX_UNIQUE_VALUES``
+  environment variable with sensible fallbacks for garbage input.
+- Values below 2 are rejected (a threshold below 2 would drop every
+  column, since Rule-of-N also rejects columns with <= 1 unique
+  values).
+"""
+
+import io
+import os
+import unittest
+from unittest import mock
+
+import pandas as pd
+
+from dataset.loader import DEFAULT_MAX_UNIQUE_VALUES, DataLoader
+from main import (
+    prepare_for_categorical,
+    prepare_for_model,
+    prepare_for_training,
+)
+
+
+def _csv_bytes(df: pd.DataFrame) -> bytes:
+    buf = io.BytesIO()
+    df.to_csv(buf, index=False)
+    return buf.getvalue()
+
+
+def _make_loader(max_unique_values=None) -> DataLoader:
+    return DataLoader(
+        drop_columns=[],
+        rename_columns={},
+        columns_of_interest=[],
+        max_unique_values=max_unique_values,
+    )
+
+
+def _sample_df_with_varied_cardinalities() -> pd.DataFrame:
+    """Fixture: each column has a known distinct cardinality from 2 to 15."""
+    return pd.DataFrame({
+        "card_2": ["a", "b"] * 30,
+        "card_5": ["a", "b", "c", "d", "e"] * 12,
+        "card_9": [f"v{i % 9}" for i in range(60)],
+        "card_12": [f"v{i % 12}" for i in range(60)],
+        "card_15": [f"v{i % 15}" for i in range(60)],
+    })
+
+
+class TestDefaultThresholdUnchanged(unittest.TestCase):
+    """The default behaviour must match the historical Rule of 9."""
+
+    def test_default_constant_is_9(self):
+        self.assertEqual(DEFAULT_MAX_UNIQUE_VALUES, 9)
+
+    def test_default_loader_keeps_up_to_9(self):
+        loader = _make_loader()  # default threshold
+        self.assertEqual(loader.max_unique_values, 9)
+
+        df = _sample_df_with_varied_cardinalities()
+        clean_df, meta = loader.load_uploaded_csv(_csv_bytes(df))
+
+        # Columns with 2, 5, 9 unique values survive; 12 and 15 are dropped.
+        self.assertIn("card_2", clean_df.columns)
+        self.assertIn("card_5", clean_df.columns)
+        self.assertIn("card_9", clean_df.columns)
+        self.assertNotIn("card_12", clean_df.columns)
+        self.assertNotIn("card_15", clean_df.columns)
+
+        ignored_names = {c["name"] for c in meta["ignored_columns"]}
+        self.assertEqual(ignored_names, {"card_12", "card_15"})
+
+
+class TestDataLoaderThreshold(unittest.TestCase):
+    """DataLoader must honour the configured threshold."""
+
+    def test_loader_with_high_threshold_keeps_more_columns(self):
+        loader = _make_loader(max_unique_values=15)
+        self.assertEqual(loader.max_unique_values, 15)
+
+        df = _sample_df_with_varied_cardinalities()
+        clean_df, meta = loader.load_uploaded_csv(_csv_bytes(df))
+
+        # All five columns have <= 15 unique values, so all survive.
+        for col in ["card_2", "card_5", "card_9", "card_12", "card_15"]:
+            self.assertIn(col, clean_df.columns)
+
+        ignored_names = {c["name"] for c in meta["ignored_columns"]}
+        self.assertEqual(ignored_names, set())
+
+    def test_loader_with_low_threshold_drops_more_columns(self):
+        loader = _make_loader(max_unique_values=4)
+        self.assertEqual(loader.max_unique_values, 4)
+
+        df = _sample_df_with_varied_cardinalities()
+        clean_df, meta = loader.load_uploaded_csv(_csv_bytes(df))
+
+        # Only card_2 has <= 4 unique values.
+        self.assertEqual(list(clean_df.columns), ["card_2"])
+
+        ignored_names = {c["name"] for c in meta["ignored_columns"]}
+        self.assertEqual(
+            ignored_names, {"card_5", "card_9", "card_12", "card_15"}
+        )
+
+        # Ignored metadata should report each column's actual cardinality
+        # alongside a reason that mentions the configured threshold.
+        for entry in meta["ignored_columns"]:
+            self.assertGreater(entry["unique_values"], 4)
+            self.assertIn("4", entry["reason"])
+
+    def test_loader_threshold_still_drops_single_value_columns(self):
+        """Dropping constant columns is independent of N — they must
+        still be filtered even with a very high threshold."""
+        loader = _make_loader(max_unique_values=50)
+        df = pd.DataFrame({
+            "constant": ["x"] * 20,
+            "varied": ["a", "b", "a", "b"] * 5,
+        })
+        clean_df, meta = loader.load_uploaded_csv(_csv_bytes(df))
+
+        self.assertNotIn("constant", clean_df.columns)
+        self.assertIn("varied", clean_df.columns)
+
+    def test_per_call_override_beats_instance_default(self):
+        """``prepare_original_dataset`` accepts a per-call override."""
+        loader = _make_loader(max_unique_values=9)  # historical default
+        df = _sample_df_with_varied_cardinalities()
+
+        # Per-call override widens the window to 15.
+        clean_df, meta = loader.prepare_original_dataset(
+            df.copy(), replacements={}, max_unique_values=15
+        )
+        self.assertIn("card_12", clean_df.columns)
+        self.assertIn("card_15", clean_df.columns)
+
+        # Instance default is unchanged.
+        self.assertEqual(loader.max_unique_values, 9)
+
+    def test_loader_rejects_threshold_below_two(self):
+        with self.assertRaises(ValueError):
+            _make_loader(max_unique_values=1)
+        with self.assertRaises(ValueError):
+            _make_loader(max_unique_values=0)
+
+    def test_prepare_original_dataset_rejects_per_call_threshold_below_two(self):
+        loader = _make_loader()
+        with self.assertRaises(ValueError):
+            loader.prepare_original_dataset(
+                pd.DataFrame({"a": ["x", "y"]}),
+                replacements={},
+                max_unique_values=1,
+            )
+
+
+class TestMainHelpers(unittest.TestCase):
+    """The main.py cleaning / vectorization helpers must thread the
+    threshold through correctly."""
+
+    def test_prepare_for_categorical_default(self):
+        df = _sample_df_with_varied_cardinalities()
+        clean_df = prepare_for_categorical(df)
+        self.assertEqual(
+            set(clean_df.columns), {"card_2", "card_5", "card_9"}
+        )
+
+    def test_prepare_for_categorical_with_high_threshold(self):
+        df = _sample_df_with_varied_cardinalities()
+        clean_df = prepare_for_categorical(df, max_unique_values=15)
+        self.assertEqual(
+            set(clean_df.columns),
+            {"card_2", "card_5", "card_9", "card_12", "card_15"},
+        )
+
+    def test_prepare_for_categorical_with_low_threshold(self):
+        df = _sample_df_with_varied_cardinalities()
+        clean_df = prepare_for_categorical(df, max_unique_values=4)
+        self.assertEqual(set(clean_df.columns), {"card_2"})
+
+    def test_prepare_for_categorical_rejects_threshold_below_two(self):
+        with self.assertRaises(ValueError):
+            prepare_for_categorical(
+                pd.DataFrame({"a": ["x", "y"]}), max_unique_values=1
+            )
+
+    def test_prepare_for_model_threads_threshold(self):
+        df = _sample_df_with_varied_cardinalities()
+        cleaned_df, vectorized_df, vectorizer, cardinalities = prepare_for_model(
+            df, variable_types=None, max_unique_values=12
+        )
+
+        self.assertEqual(
+            set(cleaned_df.columns),
+            {"card_2", "card_5", "card_9", "card_12"},
+        )
+        # Vectorized width should match the sum of per-column cardinalities
+        # of the *kept* columns (2 + 5 + 9 + 12 = 28).
+        self.assertEqual(vectorized_df.shape[1], sum(cardinalities))
+        self.assertEqual(sum(cardinalities), 2 + 5 + 9 + 12)
+
+    def test_prepare_for_training_threads_threshold(self):
+        # Use a larger dataset so the train/test split has rows on both
+        # sides even for columns with up to 15 unique values.
+        df = pd.concat(
+            [_sample_df_with_varied_cardinalities()] * 5, ignore_index=True
+        )
+        cleaned_df, X_train, X_test, vectorizer, cardinalities = prepare_for_training(
+            df, variable_types=None, test_size=0.2, max_unique_values=15
+        )
+
+        self.assertEqual(
+            set(cleaned_df.columns),
+            {"card_2", "card_5", "card_9", "card_12", "card_15"},
+        )
+        # Full one-hot width: 2 + 5 + 9 + 12 + 15 = 43
+        self.assertEqual(sum(cardinalities), 2 + 5 + 9 + 12 + 15)
+        self.assertEqual(X_train.shape[1], sum(cardinalities))
+        self.assertEqual(X_test.shape[1], sum(cardinalities))
+
+
+class TestWorkerEnvVarResolution(unittest.TestCase):
+    """``worker._resolve_max_unique_values`` reads MAX_UNIQUE_VALUES
+    with graceful fallback for invalid values."""
+
+    def _resolve(self):
+        # Lazy import so this test file does not load worker.py (and its
+        # GCP client init) unless this class actually runs.
+        from worker import _resolve_max_unique_values
+        return _resolve_max_unique_values()
+
+    def test_resolve_default_when_env_var_unset(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MAX_UNIQUE_VALUES", None)
+            self.assertEqual(self._resolve(), DEFAULT_MAX_UNIQUE_VALUES)
+
+    def test_resolve_default_when_env_var_empty(self):
+        with mock.patch.dict(os.environ, {"MAX_UNIQUE_VALUES": ""}):
+            self.assertEqual(self._resolve(), DEFAULT_MAX_UNIQUE_VALUES)
+
+    def test_resolve_reads_valid_int(self):
+        with mock.patch.dict(os.environ, {"MAX_UNIQUE_VALUES": "20"}):
+            self.assertEqual(self._resolve(), 20)
+
+    def test_resolve_ignores_non_integer(self):
+        with mock.patch.dict(os.environ, {"MAX_UNIQUE_VALUES": "abc"}):
+            self.assertEqual(self._resolve(), DEFAULT_MAX_UNIQUE_VALUES)
+
+    def test_resolve_ignores_below_two(self):
+        with mock.patch.dict(os.environ, {"MAX_UNIQUE_VALUES": "1"}):
+            self.assertEqual(self._resolve(), DEFAULT_MAX_UNIQUE_VALUES)
+        with mock.patch.dict(os.environ, {"MAX_UNIQUE_VALUES": "-5"}):
+            self.assertEqual(self._resolve(), DEFAULT_MAX_UNIQUE_VALUES)
+
+
+class TestTrainTaskEnvVarResolution(unittest.TestCase):
+    """``train.task._resolve_max_unique_values`` mirrors the worker's
+    env var reader for Vertex AI containers."""
+
+    def _resolve(self):
+        from train.task import _resolve_max_unique_values
+        return _resolve_max_unique_values()
+
+    def test_resolve_default_when_env_var_unset(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MAX_UNIQUE_VALUES", None)
+            self.assertEqual(self._resolve(), DEFAULT_MAX_UNIQUE_VALUES)
+
+    def test_resolve_reads_valid_int(self):
+        with mock.patch.dict(os.environ, {"MAX_UNIQUE_VALUES": "7"}):
+            self.assertEqual(self._resolve(), 7)
+
+    def test_resolve_ignores_invalid_values(self):
+        for raw in ("0", "1", "-3", "not-a-number", "9.5"):
+            with mock.patch.dict(os.environ, {"MAX_UNIQUE_VALUES": raw}):
+                self.assertEqual(self._resolve(), DEFAULT_MAX_UNIQUE_VALUES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rule_of_n.py
+++ b/tests/test_rule_of_n.py
@@ -22,6 +22,9 @@ These tests verify that the threshold is now configurable end-to-end:
 - Values below 2 are rejected (a threshold below 2 would drop every
   column, since Rule-of-N also rejects columns with <= 1 unique
   values).
+- ``apply_rule_of_n=False`` disables the filter entirely so scoring
+  paths with a saved vectorizer do not silently drop high-cardinality
+  columns that the vectorizer was trained on (Codex P1 PR#49).
 """
 
 import io
@@ -32,7 +35,9 @@ from unittest import mock
 import pandas as pd
 
 from dataset.loader import DEFAULT_MAX_UNIQUE_VALUES, DataLoader
+from features.transform import Table2Vector
 from main import (
+    _clean_for_saved_vectorizer,
     prepare_for_categorical,
     prepare_for_model,
     prepare_for_training,
@@ -45,12 +50,13 @@ def _csv_bytes(df: pd.DataFrame) -> bytes:
     return buf.getvalue()
 
 
-def _make_loader(max_unique_values=None) -> DataLoader:
+def _make_loader(max_unique_values=None, apply_rule_of_n=True) -> DataLoader:
     return DataLoader(
         drop_columns=[],
         rename_columns={},
         columns_of_interest=[],
         max_unique_values=max_unique_values,
+        apply_rule_of_n=apply_rule_of_n,
     )
 
 
@@ -291,6 +297,216 @@ class TestTrainTaskEnvVarResolution(unittest.TestCase):
         for raw in ("0", "1", "-3", "not-a-number", "9.5"):
             with mock.patch.dict(os.environ, {"MAX_UNIQUE_VALUES": raw}):
                 self.assertEqual(self._resolve(), DEFAULT_MAX_UNIQUE_VALUES)
+
+
+class TestApplyRuleOfNFlag(unittest.TestCase):
+    """``apply_rule_of_n=False`` bypasses the Rule-of-N filter entirely
+    so scoring paths with a saved vectorizer can let the vectorizer be
+    the authoritative source of truth on kept columns (Codex P1 PR#49).
+    """
+
+    def test_default_applies_filter(self):
+        loader = _make_loader()
+        self.assertTrue(loader.apply_rule_of_n)
+
+    def test_explicit_false_disables_filter(self):
+        loader = _make_loader(apply_rule_of_n=False)
+        self.assertFalse(loader.apply_rule_of_n)
+
+    def test_filter_disabled_keeps_high_cardinality_columns(self):
+        """With ``apply_rule_of_n=False``, all columns survive even if
+        their cardinality exceeds ``max_unique_values``."""
+        loader = _make_loader(
+            max_unique_values=9, apply_rule_of_n=False
+        )
+        df = _sample_df_with_varied_cardinalities()
+        clean_df, meta = loader.load_uploaded_csv(_csv_bytes(df))
+
+        # Every column survives regardless of its cardinality.
+        for col in ["card_2", "card_5", "card_9", "card_12", "card_15"]:
+            self.assertIn(col, clean_df.columns)
+        self.assertEqual(meta["ignored_columns"], [])
+
+    def test_filter_disabled_keeps_constant_columns(self):
+        """``apply_rule_of_n=False`` also skips the lower bound —
+        single-value columns survive so that the vectorizer can align
+        them to trained columns."""
+        loader = _make_loader(apply_rule_of_n=False)
+        df = pd.DataFrame({
+            "constant": ["yes"] * 20,
+            "varied": ["a", "b", "a", "b"] * 5,
+        })
+        clean_df, meta = loader.load_uploaded_csv(_csv_bytes(df))
+
+        self.assertIn("constant", clean_df.columns)
+        self.assertIn("varied", clean_df.columns)
+        self.assertEqual(meta["ignored_columns"], [])
+
+    def test_per_call_apply_rule_of_n_override(self):
+        """``prepare_original_dataset`` accepts a per-call
+        ``apply_rule_of_n`` override that beats the instance default."""
+        loader = _make_loader(apply_rule_of_n=True)
+        df = _sample_df_with_varied_cardinalities()
+
+        # Per-call override disables the filter.
+        clean_df, meta = loader.prepare_original_dataset(
+            df.copy(),
+            replacements={},
+            apply_rule_of_n=False,
+        )
+        for col in ["card_2", "card_5", "card_9", "card_12", "card_15"]:
+            self.assertIn(col, clean_df.columns)
+        self.assertEqual(meta["ignored_columns"], [])
+
+        # Instance default is unchanged — a follow-up call without the
+        # override re-applies the default threshold.
+        self.assertTrue(loader.apply_rule_of_n)
+        clean_df2, meta2 = loader.prepare_original_dataset(
+            df.copy(), replacements={}
+        )
+        self.assertNotIn("card_12", clean_df2.columns)
+        self.assertNotIn("card_15", clean_df2.columns)
+
+    def test_filter_disabled_still_casts_to_string(self):
+        """``apply_rule_of_n=False`` still converts columns to
+        strings so downstream one-hot encoding receives consistent
+        dtypes."""
+        loader = _make_loader(apply_rule_of_n=False)
+        df = pd.DataFrame({
+            "cat": ["a", "b", "a", "b"] * 5,
+            "many": [f"v{i}" for i in range(20)],
+        })
+        clean_df, _ = loader.load_uploaded_csv(_csv_bytes(df))
+
+        # Accept either object dtype (pandas <= 2.x) or StringDtype
+        # (pandas 3.x default). What matters is that the values are
+        # Python ``str`` instances that Table2Vector will accept.
+        for col in clean_df.columns:
+            self.assertTrue(
+                all(isinstance(v, str) for v in clean_df[col]),
+                f"column {col!r} contains non-string values",
+            )
+
+
+class TestSavedVectorizerScoringRegression(unittest.TestCase):
+    """End-to-end regression for Codex P1 PR#49: a model trained with
+    ``max_unique_values=15`` must continue to score correctly on the
+    same data even when the scoring-time CLI default is the historical
+    9. The bug was that the default threshold silently dropped the
+    high-cardinality columns at load time, and
+    ``_clean_for_saved_vectorizer`` re-inserted them as constant
+    ``"missing"`` values, corrupting the one-hot matrix the model sees.
+
+    With the fix, scoring paths detect the saved vectorizer and
+    disable the Rule-of-N filter on the DataLoader, so the kept
+    columns match the vectorizer's ``var_types`` and the transformed
+    matrix is identical to the one produced at training time.
+    """
+
+    def test_training_threshold_preserved_at_scoring_time(self):
+        # Training data with a column whose cardinality exceeds the
+        # historical Rule-of-9 default.
+        df = pd.DataFrame({
+            "card_4": ["a", "b", "c", "d"] * 15,
+            "card_12": [f"v{i % 12}" for i in range(60)],
+        })
+
+        # --- Training path: user explicitly widens the threshold to 15
+        train_loader = _make_loader(max_unique_values=15)
+        clean_train, meta_train = train_loader.load_uploaded_csv(
+            _csv_bytes(df)
+        )
+        self.assertIn("card_4", clean_train.columns)
+        self.assertIn("card_12", clean_train.columns)
+
+        variable_types = meta_train["variable_types"]
+        vectorizer = Table2Vector(variable_types)
+        vectorizer.fit(clean_train)
+
+        trained_cols = list(
+            vectorizer.var_types.get("categorical", [])
+        ) + list(vectorizer.var_types.get("numeric", []))
+        self.assertIn("card_12", trained_cols)
+
+        expected_transformed = vectorizer.transform(clean_train).astype(
+            "float32"
+        )
+
+        # --- Scoring path: no `--max_unique_values` passed, so the
+        # CLI default of 9 applies. Before the fix this silently drops
+        # ``card_12``. With the fix, we detect the saved vectorizer and
+        # construct the DataLoader with ``apply_rule_of_n=False``.
+        score_loader = _make_loader(
+            max_unique_values=DEFAULT_MAX_UNIQUE_VALUES,
+            apply_rule_of_n=False,  # what evaluate/find_outliers/generate do
+        )
+        clean_score, _ = score_loader.load_uploaded_csv(_csv_bytes(df))
+
+        # Critical assertion: ``card_12`` survives load_data instead of
+        # being dropped and then silently backfilled.
+        self.assertIn("card_12", clean_score.columns)
+        self.assertIn("card_4", clean_score.columns)
+
+        aligned = _clean_for_saved_vectorizer(clean_score, vectorizer)
+        scored = vectorizer.transform(aligned).astype("float32")
+
+        # The scoring-time transformed matrix must match the
+        # training-time matrix exactly (same shape, same values).
+        self.assertEqual(scored.shape, expected_transformed.shape)
+        self.assertTrue(
+            (scored.values == expected_transformed.values).all(),
+            "scoring-time transform differs from training-time transform",
+        )
+
+    def test_regression_default_threshold_would_corrupt_inputs(self):
+        """Proof that the old code path *was* broken: if the DataLoader
+        still applies the default Rule-of-N=9 filter, the high-card
+        column is dropped and backfilled as constant ``"missing"``,
+        producing a transformed matrix that differs from training. This
+        test pins the faulty behaviour so a future regression that
+        silently re-enables the filter will fail loudly.
+        """
+        df = pd.DataFrame({
+            "card_4": ["a", "b", "c", "d"] * 15,
+            "card_12": [f"v{i % 12}" for i in range(60)],
+        })
+
+        train_loader = _make_loader(max_unique_values=15)
+        clean_train, meta_train = train_loader.load_uploaded_csv(
+            _csv_bytes(df)
+        )
+        variable_types = meta_train["variable_types"]
+        vectorizer = Table2Vector(variable_types)
+        vectorizer.fit(clean_train)
+        expected = vectorizer.transform(clean_train).astype("float32")
+
+        # Simulate the broken pre-fix path: scoring loader uses the
+        # default threshold (9) *and* apply_rule_of_n is left True.
+        broken_loader = _make_loader(
+            max_unique_values=DEFAULT_MAX_UNIQUE_VALUES,
+            apply_rule_of_n=True,
+        )
+        clean_broken, meta_broken = broken_loader.load_uploaded_csv(
+            _csv_bytes(df)
+        )
+        # card_12 is dropped by Rule-of-9.
+        self.assertNotIn("card_12", clean_broken.columns)
+
+        aligned_broken = _clean_for_saved_vectorizer(
+            clean_broken, vectorizer
+        )
+        scored_broken = vectorizer.transform(aligned_broken).astype(
+            "float32"
+        )
+
+        # Shapes match (alignment adds the column back), but values
+        # diverge because card_12 became a constant "missing" column.
+        self.assertEqual(scored_broken.shape, expected.shape)
+        self.assertFalse(
+            (scored_broken.values == expected.values).all(),
+            "broken path happens to match training transform — the "
+            "regression guard below is therefore meaningless",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_rule_of_n.py
+++ b/tests/test_rule_of_n.py
@@ -388,6 +388,138 @@ class TestApplyRuleOfNFlag(unittest.TestCase):
             )
 
 
+class TestVertexContainerArgPropagation(unittest.TestCase):
+    """The Rule-of-N threshold must flow from the worker dispatcher
+    into the Vertex AI training container via a CLI arg, because
+    ``CustomContainerTrainingJob.run()`` does not forward the
+    dispatcher's env vars to the container (Codex P1 PR#49).
+    """
+
+    def test_build_vertex_args_includes_max_unique_values(self):
+        from worker import _build_vertex_training_args
+
+        args = _build_vertex_training_args(
+            "job-123",
+            "my-bucket",
+            "uploads/job-123/data.csv",
+            max_unique_values=15,
+        )
+        self.assertIn("--job-id=job-123", args)
+        self.assertIn("--bucket-name=my-bucket", args)
+        self.assertIn("--file-path=uploads/job-123/data.csv", args)
+        self.assertIn("--max-unique-values=15", args)
+
+    def test_build_vertex_args_omits_max_unique_values_when_none(self):
+        """Backwards compat: when ``max_unique_values=None`` (not
+        supplied), the arg is omitted so a Vertex container running an
+        older ``train/task.py`` that doesn't recognise the flag still
+        accepts the args."""
+        from worker import _build_vertex_training_args
+
+        args = _build_vertex_training_args(
+            "job-123",
+            "my-bucket",
+            "uploads/job-123/data.csv",
+            max_unique_values=None,
+        )
+        self.assertEqual(
+            args,
+            [
+                "--job-id=job-123",
+                "--bucket-name=my-bucket",
+                "--file-path=uploads/job-123/data.csv",
+            ],
+        )
+
+    def test_build_vertex_args_coerces_to_int_string(self):
+        """Any numeric value is emitted as a base-10 int string so
+        ``argparse`` on the container side parses it cleanly."""
+        from worker import _build_vertex_training_args
+
+        args = _build_vertex_training_args(
+            "j",
+            "b",
+            "f",
+            max_unique_values=9.0,  # e.g. float from a YAML config
+        )
+        self.assertIn("--max-unique-values=9", args)
+
+    def test_worker_forwards_env_var_to_vertex(self):
+        """End-to-end: when the operator sets MAX_UNIQUE_VALUES=20 on
+        the worker, the helper that builds the Vertex CLI args picks
+        it up via ``_resolve_max_unique_values`` (the same function
+        used by the local path) so both modes stay in sync."""
+        from worker import (
+            _build_vertex_training_args,
+            _resolve_max_unique_values,
+        )
+
+        with mock.patch.dict(os.environ, {"MAX_UNIQUE_VALUES": "20"}):
+            args = _build_vertex_training_args(
+                "j",
+                "b",
+                "f",
+                max_unique_values=_resolve_max_unique_values(),
+            )
+        self.assertIn("--max-unique-values=20", args)
+
+    def test_train_task_cli_accepts_max_unique_values(self):
+        """``train/task.py``'s argparse must accept the new flag so
+        the dispatcher's CLI arg lands somewhere on the container
+        side."""
+        import argparse
+
+        # Mirror the argparse config in train/task.py's __main__.
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--job-id", type=str, required=True)
+        parser.add_argument("--bucket-name", type=str, required=True)
+        parser.add_argument("--file-path", type=str, required=True)
+        parser.add_argument(
+            "--max-unique-values",
+            type=int,
+            default=None,
+            dest="max_unique_values",
+        )
+        parsed = parser.parse_args([
+            "--job-id=j",
+            "--bucket-name=b",
+            "--file-path=f",
+            "--max-unique-values=15",
+        ])
+        self.assertEqual(parsed.max_unique_values, 15)
+
+        # And it's optional, defaulting to None.
+        parsed2 = parser.parse_args([
+            "--job-id=j",
+            "--bucket-name=b",
+            "--file-path=f",
+        ])
+        self.assertIsNone(parsed2.max_unique_values)
+
+    def test_train_task_module_registers_same_cli_contract(self):
+        """Drift guard: if someone renames/removes ``--max-unique-values``
+        on ``train/task.py``, this test fails so the worker→container
+        contract stays aligned."""
+        import pathlib
+        source_path = pathlib.Path(__file__).resolve().parents[1] / "train" / "task.py"
+        source = source_path.read_text()
+        self.assertIn("--max-unique-values", source)
+        self.assertIn("max_unique_values", source)
+
+    def test_train_task_train_and_predict_accepts_max_unique_values(self):
+        """``train_and_predict`` must accept ``max_unique_values`` as a
+        keyword argument so the CLI layer can forward the parsed flag
+        to it without the function ignoring or error-ing."""
+        import inspect
+        from train.task import train_and_predict
+
+        sig = inspect.signature(train_and_predict)
+        self.assertIn("max_unique_values", sig.parameters)
+        self.assertEqual(
+            sig.parameters["max_unique_values"].default, None
+        )
+
+
 class TestSavedVectorizerScoringRegression(unittest.TestCase):
     """End-to-end regression for Codex P1 PR#49: a model trained with
     ``max_unique_values=15`` must continue to score correctly on the

--- a/train/task.py
+++ b/train/task.py
@@ -60,7 +60,25 @@ def _resolve_max_unique_values(default=DEFAULT_MAX_UNIQUE_VALUES):
     return value
 
 
-def train_and_predict(job_id, bucket_name, file_path):
+def train_and_predict(job_id, bucket_name, file_path, max_unique_values=None):
+    """Run the end-to-end Vertex training pipeline.
+
+    Args:
+        job_id: Firestore job document ID.
+        bucket_name: GCS bucket containing the uploaded CSV.
+        file_path: GCS object path to the uploaded CSV.
+        max_unique_values: Optional explicit Rule-of-N threshold. When
+            ``None`` we fall back to the ``MAX_UNIQUE_VALUES``
+            environment variable (via ``_resolve_max_unique_values``).
+            The dispatcher in ``worker.process_upload_vertex`` passes
+            this in as a CLI argument (``--max-unique-values=N``)
+            because the Vertex training container does NOT inherit the
+            dispatcher process's env vars — without explicit
+            propagation the container silently defaulted to 9 even
+            when the worker had ``MAX_UNIQUE_VALUES=15`` set,
+            producing inconsistent feature filtering between local
+            and Vertex modes (Codex P1 PR#49).
+    """
     try:
         logger.info(f"Starting Vertex AI Job for {job_id}")
 
@@ -75,8 +93,11 @@ def train_and_predict(job_id, bucket_name, file_path):
         df = loader.load_original_data(csv_bytes)
 
         # Rule of N Filter (TASKS.md 3.1: threshold is configurable via
-        # the MAX_UNIQUE_VALUES env var; defaults to 9).
-        max_unique_values = _resolve_max_unique_values()
+        # the --max-unique-values CLI arg or MAX_UNIQUE_VALUES env var;
+        # defaults to 9).
+        if max_unique_values is None:
+            max_unique_values = _resolve_max_unique_values()
+        logger.info(f"Using Rule-of-N threshold: {max_unique_values}")
         stats = {"total_rows": len(df), "kept_columns": [], "ignored_columns": []}
         process_df = df.fillna("missing").astype(str)
 
@@ -210,6 +231,24 @@ if __name__ == "__main__":
     parser.add_argument('--job-id', type=str, required=True)
     parser.add_argument('--bucket-name', type=str, required=True)
     parser.add_argument('--file-path', type=str, required=True)
+    # Rule-of-N threshold forwarded from worker.process_upload_vertex.
+    # Optional: when absent we fall back to the MAX_UNIQUE_VALUES env
+    # var, which in turn falls back to the module default (9). Vertex
+    # AI CustomContainerTrainingJob.run() does not propagate the
+    # dispatcher's env vars to the training container, so this CLI
+    # arg is the only reliable channel for the override (Codex P1
+    # PR#49).
+    parser.add_argument(
+        '--max-unique-values',
+        type=int,
+        default=None,
+        dest='max_unique_values',
+    )
     args = parser.parse_args()
-    
-    train_and_predict(args.job_id, args.bucket_name, args.file_path)
+
+    train_and_predict(
+        args.job_id,
+        args.bucket_name,
+        args.file_path,
+        max_unique_values=args.max_unique_values,
+    )

--- a/train/task.py
+++ b/train/task.py
@@ -19,7 +19,7 @@ import os
 import numpy as np
 import pandas as pd
 from google.cloud import storage, firestore
-from dataset.loader import DataLoader
+from dataset.loader import DataLoader, DEFAULT_MAX_UNIQUE_VALUES
 from evaluate.outliers import compute_reconstruction_error
 from features.transform import Table2Vector
 from model.autoencoder import AutoencoderModel
@@ -30,37 +30,72 @@ logger = logging.getLogger(__name__)
 # Force the client to use YOUR specific project, not the internal Google one
 db = firestore.Client(project=os.getenv("GOOGLE_CLOUD_PROJECT", "autoencoders-census"))
 
+
+def _resolve_max_unique_values(default=DEFAULT_MAX_UNIQUE_VALUES):
+    """Read the Rule-of-N threshold from the ``MAX_UNIQUE_VALUES`` env
+    var, falling back to the built-in default (TASKS.md 3.1).
+
+    Vertex AI containers inherit environment variables from the
+    submitting worker, so setting ``MAX_UNIQUE_VALUES`` on the job
+    environment propagates to the training container without code
+    changes.
+    """
+    raw = os.getenv("MAX_UNIQUE_VALUES")
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            f"Ignoring non-integer MAX_UNIQUE_VALUES={raw!r}; "
+            f"using default ({default})"
+        )
+        return default
+    if value < 2:
+        logger.warning(
+            f"Ignoring MAX_UNIQUE_VALUES={value} (must be >= 2); "
+            f"using default ({default})"
+        )
+        return default
+    return value
+
+
 def train_and_predict(job_id, bucket_name, file_path):
     try:
         logger.info(f"Starting Vertex AI Job for {job_id}")
-        
+
         # 1. Download Data
         storage_client = storage.Client()
         bucket = storage_client.bucket(bucket_name)
-        blob = bucket.blob(file_path) 
+        blob = bucket.blob(file_path)
         csv_bytes = blob.download_as_bytes()
-        
+
         # 2. Load and Clean
         loader = DataLoader(drop_columns=[], rename_columns={}, columns_of_interest=[])
         df = loader.load_original_data(csv_bytes)
-        
-        # Rule of 9 Filter
+
+        # Rule of N Filter (TASKS.md 3.1: threshold is configurable via
+        # the MAX_UNIQUE_VALUES env var; defaults to 9).
+        max_unique_values = _resolve_max_unique_values()
         stats = {"total_rows": len(df), "kept_columns": [], "ignored_columns": []}
         process_df = df.fillna("missing").astype(str)
-        
+
         cols_to_keep = []
         for col in process_df.columns:
             unique_count = process_df[col].nunique()
-            if 1 < unique_count <= 9:
+            if 1 < unique_count <= max_unique_values:
                 cols_to_keep.append(col)
                 stats["kept_columns"].append({"name": col, "unique_values": unique_count})
             else:
                 stats["ignored_columns"].append({"name": col, "unique_values": unique_count})
-                
+
         process_df = process_df[cols_to_keep]
-        
+
         if process_df.shape[1] == 0:
-            raise ValueError("All columns were dropped! No columns fit the Rule of 9.")
+            raise ValueError(
+                f"All columns were dropped! No columns fit the Rule of N "
+                f"(N={max_unique_values})."
+            )
 
         # 3. Vectorization & model setup (split before fitting to prevent data leakage)
         from sklearn.model_selection import train_test_split as _tts

--- a/worker.py
+++ b/worker.py
@@ -128,6 +128,42 @@ def _resolve_max_unique_values(default=DEFAULT_MAX_UNIQUE_VALUES):
     return value
 
 
+def _build_vertex_training_args(job_id, bucket_name, file_path, max_unique_values=None):
+    """Build the CLI arg list for the Vertex training container.
+
+    ``CustomContainerTrainingJob.run()`` does NOT forward the
+    dispatcher process's environment variables to the training
+    container, so any ``MAX_UNIQUE_VALUES`` override set on the
+    worker would be silently ignored by ``train/task.py``. We
+    therefore propagate the Rule-of-N threshold explicitly via the
+    ``--max-unique-values`` CLI arg (Codex P1 PR#49).
+
+    The arg is only appended when a non-``None`` value is supplied so
+    that a Vertex container running an older ``train/task.py`` (which
+    doesn't yet recognise the flag) still accepts the arg list from
+    the current dispatcher during a rolling deploy.
+
+    Args:
+        job_id: Firestore job document ID.
+        bucket_name: GCS bucket containing the uploaded CSV.
+        file_path: GCS object path to the uploaded CSV.
+        max_unique_values: Rule-of-N threshold to forward, or
+            ``None`` to leave it out entirely (so the container
+            falls back to its own default).
+
+    Returns:
+        list[str]: the ``args`` parameter to pass to ``job.run()``.
+    """
+    args = [
+        f"--job-id={job_id}",
+        f"--bucket-name={bucket_name}",
+        f"--file-path={file_path}",
+    ]
+    if max_unique_values is not None:
+        args.append(f"--max-unique-values={int(max_unique_values)}")
+    return args
+
+
 class PubSubMessage(BaseModel):
     """Pydantic model for validating Pub/Sub message payload."""
     jobId: str = Field(..., min_length=1, description="Firestore job document ID")
@@ -1708,12 +1744,19 @@ def process_upload_vertex(job_id, bucket_name, file_path, message):
             container_uri=container_uri
         )
 
+        # Forward the Rule-of-N threshold explicitly as a CLI arg —
+        # Vertex AI does NOT propagate the dispatcher's env vars to
+        # the training container, so MAX_UNIQUE_VALUES on the worker
+        # would otherwise be silently ignored by train/task.py.
+        vertex_args = _build_vertex_training_args(
+            job_id,
+            bucket_name,
+            file_path,
+            max_unique_values=_resolve_max_unique_values(),
+        )
+
         job.run(
-            args=[
-                f"--job-id={job_id}",
-                f"--bucket-name={bucket_name}",
-                f"--file-path={file_path}"
-            ],
+            args=vertex_args,
             replica_count=1,
             service_account=os.getenv("VERTEX_SERVICE_ACCOUNT", "203111407489-compute@developer.gserviceaccount.com"),
             machine_type="n1-standard-4",

--- a/worker.py
+++ b/worker.py
@@ -128,6 +128,51 @@ def _resolve_max_unique_values(default=DEFAULT_MAX_UNIQUE_VALUES):
     return value
 
 
+def _resolve_explicit_max_unique_values():
+    """Like :func:`_resolve_max_unique_values` but returns ``None``
+    when the operator has not explicitly set ``MAX_UNIQUE_VALUES``
+    (or set it to an invalid value).
+
+    Used by the Vertex dispatcher to decide whether to forward the
+    ``--max-unique-values`` CLI flag to the training container. The
+    dispatcher-vs-container compatibility contract is:
+
+    - If the env var is **unset or invalid**, we do not know that the
+      operator opted in to an override, so we omit the flag. An older
+      ``train/task.py`` (which does not yet recognise the flag) then
+      parses the arg list cleanly during a rolling deploy where the
+      worker is newer than the ``trainer:v1`` image (Codex P1 PR#49).
+    - If the env var is **explicitly set** to a valid value, the
+      operator wants that value in every code path, so we forward it.
+      A mismatched-image rolling deploy in this configuration is
+      operator error — they chose to set an override before the
+      container image supported it.
+
+    The plain :func:`_resolve_max_unique_values` cannot answer this
+    question because its contract is to always return a valid int
+    (falling back to the default), which would always append the flag
+    and defeat the backwards-compat path.
+    """
+    raw = os.getenv("MAX_UNIQUE_VALUES")
+    if raw is None or raw == "":
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            f"Ignoring non-integer MAX_UNIQUE_VALUES={raw!r}; "
+            f"omitting --max-unique-values from Vertex args"
+        )
+        return None
+    if value < 2:
+        logger.warning(
+            f"Ignoring MAX_UNIQUE_VALUES={value} (must be >= 2); "
+            f"omitting --max-unique-values from Vertex args"
+        )
+        return None
+    return value
+
+
 def _build_vertex_training_args(job_id, bucket_name, file_path, max_unique_values=None):
     """Build the CLI arg list for the Vertex training container.
 
@@ -1748,11 +1793,22 @@ def process_upload_vertex(job_id, bucket_name, file_path, message):
         # Vertex AI does NOT propagate the dispatcher's env vars to
         # the training container, so MAX_UNIQUE_VALUES on the worker
         # would otherwise be silently ignored by train/task.py.
+        #
+        # We intentionally use ``_resolve_explicit_max_unique_values``
+        # here (not ``_resolve_max_unique_values``): when the operator
+        # has NOT set the env var we want to pass ``None`` so that
+        # ``_build_vertex_training_args`` omits the flag entirely and
+        # an older ``train/task.py`` in the current ``trainer:v1``
+        # image can still parse the arg list during a rolling deploy
+        # where the worker is updated before the container (Codex P1
+        # PR#49). ``_resolve_max_unique_values`` always returns an int
+        # (falling back to the default 9), which would defeat that
+        # compatibility path.
         vertex_args = _build_vertex_training_args(
             job_id,
             bucket_name,
             file_path,
-            max_unique_values=_resolve_max_unique_values(),
+            max_unique_values=_resolve_explicit_max_unique_values(),
         )
 
         job.run(

--- a/worker.py
+++ b/worker.py
@@ -42,7 +42,7 @@ from google.cloud import pubsub_v1, firestore, storage
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field, ValidationError
 
-from dataset.loader import DataLoader
+from dataset.loader import DataLoader, DEFAULT_MAX_UNIQUE_VALUES
 from features.transform import Table2Vector
 
 load_dotenv()
@@ -98,6 +98,34 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 db = firestore.Client(project=PROJECT_ID)
+
+
+def _resolve_max_unique_values(default=DEFAULT_MAX_UNIQUE_VALUES):
+    """Read the Rule-of-N threshold from the ``MAX_UNIQUE_VALUES`` env
+    var, falling back to the built-in default (TASKS.md 3.1).
+
+    Called per-job (instead of captured at module import) so an operator
+    can override the value via ``os.environ[...]`` without restarting the
+    worker process — useful for tests and short-lived deployments.
+    """
+    raw = os.getenv("MAX_UNIQUE_VALUES")
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            f"Ignoring non-integer MAX_UNIQUE_VALUES={raw!r}; "
+            f"using default ({default})"
+        )
+        return default
+    if value < 2:
+        logger.warning(
+            f"Ignoring MAX_UNIQUE_VALUES={value} (must be >= 2); "
+            f"using default ({default})"
+        )
+        return default
+    return value
 
 
 class PubSubMessage(BaseModel):
@@ -1224,11 +1252,14 @@ def process_upload_local(job_id, bucket_name, file_path, message):
         # 4. Data Cleaning
         process_df = df.fillna("missing").astype(str)
 
-        # 5. Rule of 9 Filter
+        # 5. Rule of N Filter (TASKS.md 3.1: threshold is configurable via
+        # the ``MAX_UNIQUE_VALUES`` env var; defaults to 9 to match the
+        # CLI pipeline's built-in default).
+        max_unique_values = _resolve_max_unique_values()
         cols_to_keep = []
         for col in process_df.columns:
             unique_count = process_df[col].nunique()
-            if unique_count > 1 and unique_count <= 9:
+            if 1 < unique_count <= max_unique_values:
                 cols_to_keep.append(col)
                 stats["kept_columns"].append({
                     "name": col,
@@ -1244,7 +1275,10 @@ def process_upload_local(job_id, bucket_name, file_path, message):
                 })
 
         process_df = process_df[cols_to_keep]
-        logger.info(f"After Rule of 9: {process_df.shape} (kept {len(cols_to_keep)}, ignored {len(stats['ignored_columns'])})")
+        logger.info(
+            f"After Rule of N (N={max_unique_values}): {process_df.shape} "
+            f"(kept {len(cols_to_keep)}, ignored {len(stats['ignored_columns'])})"
+        )
 
         if process_df.shape[1] == 0:
             # TASKS.md 2.3: emit a stable error code so the frontend can
@@ -1256,9 +1290,10 @@ def process_upload_local(job_id, bucket_name, file_path, message):
                 job_ref,
                 job_id,
                 "No usable columns found. Every column was dropped because "
-                "it had only one unique value or more than 9 unique values. "
-                "Try a dataset with some low-cardinality categorical "
-                "columns (between 2 and 9 distinct values).",
+                "it had only one unique value or more than "
+                f"{max_unique_values} unique values. Try a dataset with "
+                "some low-cardinality categorical columns (between 2 and "
+                f"{max_unique_values} distinct values).",
                 error_code=ErrorCode.NO_USABLE_COLUMNS,
                 error_type=ErrorType.PROCESSING,
             )


### PR DESCRIPTION
The max-unique-values threshold was hardcoded to 9 in five places:
DataLoader.prepare_original_dataset, main.prepare_for_categorical (and
its transitive callers prepare_for_model / prepare_for_training), and
the inline Rule-of-9 loops in worker.py and train/task.py. Users with
datasets of different cardinality now need to fork the code to tune it.

Changes:

- dataset/loader.py: export DEFAULT_MAX_UNIQUE_VALUES=9 as the single
  source of truth. DataLoader.__init__ takes max_unique_values so every
  loader entry point (load_2017, load_uploaded_csv, etc.) inherits it
  via self.max_unique_values. prepare_original_dataset also accepts a
  per-call override. Thresholds below 2 raise ValueError because the
  filter also drops n_unique<=1, so N<2 would drop every column.

- main.py: prepare_for_categorical, _clean_and_build_vectorizer,
  prepare_for_model, prepare_for_training, and run_training_pipeline
  thread max_unique_values through consistently. run_training_pipeline
  reads an optional max_unique_values YAML config key. Added
  --max_unique_values to train, search_hyperparameters, evaluate,
  find_outliers, chow_liu_outliers, generate, and pca_baseline. CLI
  flag > YAML config key > built-in default precedence.

- worker.py / train/task.py: read the threshold from the
  MAX_UNIQUE_VALUES environment variable via a _resolve_max_unique_values
  helper with warning-and-fallback for invalid values. Error messages
  now cite the configured threshold so operators can see which N was
  in effect for any given run.

- tests/test_rule_of_n.py: 22 new tests covering default-unchanged
  behaviour, DataLoader with high/low/per-call overrides, constant-
  column independence from N, ValueError on N<2, main.py helpers
  threading the threshold through to vectorized-matrix widths, and
  env-var parsing for both worker and train.task resolvers.

Full test suite: 216 passed, 12 skipped (cloud-dependent).

https://claude.ai/code/session_01GEBLRLUSnWvxLc9aLUZjy9