### PR TITLE
Run worker on Cloud Run via Pub/Sub push (scale-to-zero)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,49 @@
+# Keep the Cloud Build context small: ship Python source + config only.
+# (The worker reads uploaded CSVs from GCS, so no local data/artifacts needed.)
+
+.git/
+.github/
+.claude/
+
+# Python envs / caches
+venv/
+venv_ae/
+venv_ae311/
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+
+# Secrets / local env
+.env
+.env.*
+*.enc
+**/.env
+
+# Frontend (built and deployed separately as the `api` service)
+frontend/
+
+# Notebooks and exploration
+notebooks/
+
+# Large local data, model artifacts and outputs the worker doesn't need
+cache/
+wandb/
+data/*.csv
+data/*.dta
+data/*.sav
+data/*.dat
+*.png
+*.pdf
+vae/
+vae_artifacts/
+gans/
+sadc_synthetic_bn/
+sadc_synthetic_gan/
+yrbs_synthetic_pipeline/
+group_barplots/
+attention_check/
+attention_check_v2/
+attention_check_v3/
+attention_check_80perc/
+*_80perc/

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,49 @@
+# Controls what `gcloud builds submit` uploads as the build context.
+# (gcloud uses THIS file, not .dockerignore, to pick the upload set.)
+# Keep it tight: ship Python source + config only.
+
+.git/
+.github/
+.claude/
+
+# Python virtualenvs (multi-GB) and caches
+venv/
+venv_ae/
+venv_ae311/
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+
+# Node / frontend (deployed separately as the `api` service)
+frontend/
+node_modules/
+
+# Notebooks and experiment tracking
+notebooks/
+wandb/
+
+# Secrets / local env
+.env
+.env.*
+*.enc
+
+# Large local data and generated artifacts the worker doesn't need
+cache/
+data/*.csv
+data/*.dta
+data/*.sav
+data/*.dat
+*.png
+*.pdf
+vae/
+vae_artifacts/
+gans/
+sadc_synthetic_bn/
+sadc_synthetic_gan/
+yrbs_synthetic_pipeline/
+group_barplots/
+attention_check/
+attention_check_v2/
+attention_check_v3/
+*_80perc/

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,0 +1,32 @@
+# Worker container for Cloud Run (Pub/Sub *push* target).
+#
+# Runs worker_http.py, which wraps the existing worker.callback() job logic
+# behind an HTTP endpoint so Pub/Sub can push jobs to a scale-to-zero service.
+# Local development keeps using `python worker.py` (pull mode) unchanged.
+
+FROM python:3.11-slim
+
+# libgomp1 is the OpenMP runtime several wheels (TensorFlow, numba/llvmlite,
+# scikit-learn) load at import time on slim images.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install dependencies first so this layer is cached across code-only changes.
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Application code (heavy/irrelevant paths are excluded via .dockerignore).
+COPY . .
+
+# Cloud Run routes traffic to $PORT (defaults to 8080).
+ENV PORT=8080
+EXPOSE 8080
+
+# Drop root for the running process.
+RUN useradd --create-home appuser
+USER appuser
+
+CMD ["python", "worker_http.py"]

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,3 +1,4 @@
+
 # TASKS.md -- Product Launch for Survey Outlier Detection
 
 ## 1. Stabilize the Core Pipeline
@@ -784,11 +785,13 @@ Each item keeps its original TASKS.md number; completing it updates the correspo
 | Phase | Title | Status | PR | DONE summary |
 |-------|-------|--------|----|-|
 | A | Repo & deploy hygiene | Not started | — | — |
-| B | Containerization | Not started | — | — |
-| C | Pub/Sub push refactor | Not started | — | — |
-| D | GCP infra bootstrap script | Not started | — | — |
-| E | Cloud Run deploy script | Not started | — | — |
+| B | Containerization | Partial (worker only) | `claude/cloud-run-worker` | `Dockerfile.worker` + `cloudbuild.worker.yaml` shipped (worker image). `Dockerfile.api` / vertex-trainer rename / unified `cloudbuild.yaml` still TODO. |
+| C | Pub/Sub push refactor | Partial (MVP) | `claude/cloud-run-worker` | `worker_http.py` exposes `POST /pubsub/push` + `GET /healthz` and reuses `worker.callback()` via a `PushMessage` adapter (no refactor of `callback()` itself). Auth is via Cloud Run `--no-allow-unauthenticated` + invoker IAM (platform-level OIDC), NOT in-app token verification. Dead-letter topic + `tests/test_worker_http.py` still TODO. |
+| D | GCP infra bootstrap script | Partial (manual) | `claude/cloud-run-worker` | Resources created by hand (not yet scripted): SAs `ae-worker` + `ae-pubsub-pusher` with roles; push sub `job-upload-topic-push` (OIDC) + pull sub `job-upload-topic-sub` (local dev); Pub/Sub agent tokenCreator on pusher. `scripts/deploy/bootstrap.sh`, IAM conditions, DLQ still TODO. |
+| E | Cloud Run deploy script | Partial (manual) | `claude/cloud-run-worker` | `worker` service deployed manually (sizing per table, private, scale-to-zero, SA `ae-worker`). `scripts/deploy/deploy.sh` automation still TODO. |
 | F | App-code launch blockers | Not started | — | — |
 | G | Docs + TASKS.md cleanup | Not started | — | — |
+
+**Worker automation MVP (branch `claude/cloud-run-worker`, 2026-06-21):** The worker now runs on Cloud Run, triggered by a Pub/Sub *push* subscription, scale-to-zero — no idle VM. Verified end-to-end over `aletheia.stern.nyu.edu` (28k-row job processed in the cloud, Mac off). This is a focused MVP that cuts across Phases B–E; the per-phase rows above list what is shipped vs. still TODO. Set the worker service env `WORKER_MODE=vertex` to dispatch heavy jobs to Vertex AI instead of running them in-container.
 
 When picking up this plan in a new session: read this section top-to-bottom, find the first phase whose status is not `DONE`, and continue from there.

--- a/cloudbuild.worker.yaml
+++ b/cloudbuild.worker.yaml
@@ -1,0 +1,14 @@
+# Cloud Build config that builds the worker image from Dockerfile.worker.
+# Needed because `gcloud builds submit --tag` only uses the default `Dockerfile`
+# (the Vertex trainer); this lets us target a specific Dockerfile.
+#
+# Usage:
+#   gcloud builds submit --config=cloudbuild.worker.yaml \
+#     --substitutions=_IMAGE=us-central1-docker.pkg.dev/autoencoders-census/autoencoder-repo/worker:v1
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-f', 'Dockerfile.worker', '-t', '${_IMAGE}', '.']
+images:
+  - '${_IMAGE}'
+options:
+  machineType: 'E2_HIGHCPU_8'

--- a/tests/test_worker_http.py
+++ b/tests/test_worker_http.py
@@ -1,0 +1,137 @@
+"""
+Tests for worker_http.py -- the HTTP push front-end for Cloud Run.
+
+These spin up the real ThreadingHTTPServer on an ephemeral port and drive it
+with urllib so the actual BaseHTTPRequestHandler routing + status mapping is
+exercised. worker.callback is patched per-test to simulate ack / nack / raise
+without touching Firestore, GCS or TensorFlow.
+
+(conftest.py stubs the GCP client factories + required env vars, so importing
+worker_http -> worker succeeds without real credentials.)
+"""
+
+import base64
+import json
+import threading
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+from unittest.mock import Mock, patch
+
+import pytest
+
+import worker_http
+
+
+@pytest.fixture
+def server():
+    """Start worker_http.Handler on an ephemeral port; tear down after."""
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), worker_http.Handler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    host, port = httpd.server_address
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+
+def _envelope(data_str="{}", message_id="msg-1"):
+    message = {"data": base64.b64encode(data_str.encode()).decode()}
+    if message_id is not None:
+        message["messageId"] = message_id
+    return {"message": message, "subscription": "projects/p/subscriptions/s"}
+
+
+def _post(base_url, payload, path=None):
+    path = path if path is not None else worker_http.PUSH_PATH
+    body = json.dumps(payload).encode() if isinstance(payload, (dict, list)) else payload
+    req = urllib.request.Request(
+        base_url + path, data=body,
+        headers={"Content-Type": "application/json"}, method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status
+    except urllib.error.HTTPError as e:
+        return e.code
+
+
+def _get(base_url, path):
+    try:
+        with urllib.request.urlopen(base_url + path, timeout=10) as resp:
+            return resp.status
+    except urllib.error.HTTPError as e:
+        return e.code
+
+
+def test_healthz_returns_200(server):
+    assert _get(server, "/healthz") == 200
+
+
+def test_unknown_get_path_returns_404(server):
+    assert _get(server, "/nope") == 404
+
+
+def test_happy_path_ack_returns_204(server):
+    def fake_callback(msg):
+        msg.ack()
+
+    with patch.object(worker_http.worker, "callback", side_effect=fake_callback):
+        assert _post(server, _envelope()) == 204
+
+
+def test_explicit_nack_returns_503(server):
+    def fake_callback(msg):
+        msg.nack()
+
+    with patch.object(worker_http.worker, "callback", side_effect=fake_callback):
+        assert _post(server, _envelope()) == 503
+
+
+def test_callback_exception_returns_503(server):
+    def boom(msg):
+        raise RuntimeError("processing blew up")
+
+    with patch.object(worker_http.worker, "callback", side_effect=boom):
+        assert _post(server, _envelope()) == 503
+
+
+def test_callback_without_ack_or_nack_returns_503(server):
+    # Defensive: if callback() returns without deciding, NACK so Pub/Sub retries.
+    with patch.object(worker_http.worker, "callback", side_effect=lambda msg: None):
+        assert _post(server, _envelope()) == 503
+
+
+def test_malformed_envelope_is_dropped_204(server):
+    callback = Mock()
+    with patch.object(worker_http.worker, "callback", callback):
+        # No "message" key -> KeyError during parse -> ACK (drop), no callback.
+        assert _post(server, {"not": "a pubsub envelope"}) == 204
+    callback.assert_not_called()
+
+
+def test_missing_message_id_is_dropped_204(server):
+    callback = Mock()
+    with patch.object(worker_http.worker, "callback", callback):
+        assert _post(server, _envelope(message_id=None)) == 204
+    callback.assert_not_called()
+
+
+def test_wrong_post_path_returns_404(server):
+    callback = Mock()
+    with patch.object(worker_http.worker, "callback", callback):
+        assert _post(server, _envelope(), path="/some/other/path") == 404
+    callback.assert_not_called()
+
+
+def test_push_message_adapter_records_outcome():
+    msg = worker_http.PushMessage(b"data", "id-1")
+    assert msg.result is None
+    msg.modify_ack_deadline(30)  # no-op, must not raise
+    msg.ack()
+    assert msg.result == "ack"
+    msg.nack()
+    assert msg.result == "nack"

--- a/worker_http.py
+++ b/worker_http.py
@@ -17,6 +17,16 @@ Endpoints
   and **503** to NACK (transient failure -> Pub/Sub redelivers later).
 - ``GET /healthz`` -- liveness/readiness probe -> ``200 ok``.
 
+Job duration limit
+------------------
+A push job runs synchronously inside the HTTP request, so it must finish within
+the subscription's ack deadline (set to the 600s max) or Pub/Sub redelivers it.
+Redelivery is made safe by the idempotency check + Firestore state machine in
+``worker.callback()`` but wastes invocations, so in-container ``local`` mode is
+meant for sub-600s jobs. For longer jobs use ``WORKER_MODE=vertex``, which makes
+the request only *dispatch* a Vertex AI job and return in seconds. See the
+``PushMessage.modify_ack_deadline`` comment for details.
+
 Security
 --------
 The Cloud Run service is deployed with ``--no-allow-unauthenticated``, so Cloud
@@ -74,8 +84,24 @@ class PushMessage:
         self.result = "nack"
 
     def modify_ack_deadline(self, seconds: int) -> None:
-        # Pull-mode lease extension. In push mode the deadline is governed by the
-        # subscription config + HTTP response, so this is intentionally a no-op.
+        # No-op on purpose. In pull mode worker.AckExtender calls this to keep a
+        # long job's lease alive, but Pub/Sub *push* has no API to extend an
+        # individual message's deadline -- the deadline is fixed by the
+        # subscription's ackDeadlineSeconds (10s default, 600s max) and Pub/Sub
+        # decides redelivery purely from the HTTP status we return. See
+        # https://cloud.google.com/pubsub/docs/push.
+        #
+        # Consequence: a job MUST finish within the subscription ack deadline
+        # (we set it to the 600s max) or Pub/Sub will redeliver it. Redelivery
+        # is *safe* -- the idempotency check + Firestore state machine in
+        # worker.callback() drop the duplicate (JobInProgressError -> nack, then
+        # a later delivery sees the terminal state and acks) -- but it is
+        # wasteful (extra Cloud Run invocations + push backoff). Local in-
+        # container training is therefore intended for datasets that train
+        # within ~600s (the demo-scale case; a 28k-row job runs in ~110s). For
+        # larger/longer jobs set WORKER_MODE=vertex: the push request then only
+        # *dispatches* a Vertex AI custom job and returns in seconds, so the
+        # ack deadline is never at risk.
         return None
 
 

--- a/worker_http.py
+++ b/worker_http.py
@@ -1,0 +1,157 @@
+"""
+worker_http.py -- HTTP front-end for the worker, for Cloud Run + Pub/Sub *push*.
+
+Why this exists
+---------------
+``worker.py`` runs as a long-lived process that *pulls* messages off a Pub/Sub
+subscription. That model needs an always-on instance, which defeats Cloud Run's
+scale-to-zero (and costs money sitting idle). This module wraps the SAME
+job-processing logic (``worker.callback``) behind a tiny HTTP endpoint so
+Pub/Sub can *push* a message to it instead: Cloud Run wakes the container on the
+incoming request, the job runs, and the container scales back to zero when idle.
+
+Endpoints
+---------
+- ``POST /pubsub/push`` -- receives the Pub/Sub push envelope and runs the job.
+  Returns **204** to ACK (success, or a poison message we intentionally drop)
+  and **503** to NACK (transient failure -> Pub/Sub redelivers later).
+- ``GET /healthz`` -- liveness/readiness probe -> ``200 ok``.
+
+Security
+--------
+The Cloud Run service is deployed with ``--no-allow-unauthenticated``, so Cloud
+Run itself rejects any request that does not carry a valid OIDC token from the
+Pub/Sub push service account (which is granted ``roles/run.invoker``). By the
+time a request reaches this code it has already been authenticated by the
+platform, so no in-app token verification is required.
+
+Reuse
+-----
+``PushMessage`` mimics the small slice of the Pub/Sub ``Message`` interface that
+``worker.callback`` / ``process_upload_*`` depend on (``.data``, ``.message_id``,
+``.ack()``, ``.nack()``, ``.modify_ack_deadline()``) so none of the existing,
+heavily-reviewed job logic has to change. The pull-mode CLI (``worker.py``)
+keeps working unchanged for local development.
+"""
+
+import base64
+import json
+import logging
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import worker
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("worker_http")
+
+# "local" = run TensorFlow inside this container; "vertex" = dispatch the job to
+# a Vertex AI custom training job. worker.callback() reads this module global.
+worker._processing_mode = os.getenv("WORKER_MODE", "local")
+
+# Path Pub/Sub pushes to. Kept configurable so the deploy script and the
+# subscription's push endpoint stay in sync via one env var.
+PUSH_PATH = os.getenv("PUSH_PATH", "/pubsub/push")
+
+
+class PushMessage:
+    """Adapter exposing the slice of the Pub/Sub ``Message`` API the worker uses.
+
+    In push mode there is no streaming-pull lease to manage: Pub/Sub decides
+    redelivery from the HTTP status we return. ``ack()``/``nack()`` therefore
+    just record the outcome, which the handler translates into 204/503.
+    """
+
+    def __init__(self, data: bytes, message_id: str):
+        self.data = data
+        self.message_id = message_id
+        self.result = None  # "ack" | "nack" | None
+
+    def ack(self) -> None:
+        self.result = "ack"
+
+    def nack(self) -> None:
+        self.result = "nack"
+
+    def modify_ack_deadline(self, seconds: int) -> None:
+        # Pull-mode lease extension. In push mode the deadline is governed by the
+        # subscription config + HTTP response, so this is intentionally a no-op.
+        return None
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, code: int, body: str = "") -> None:
+        payload = body.encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        if payload:
+            self.wfile.write(payload)
+
+    def do_GET(self) -> None:
+        if self.path in ("/healthz", "/"):
+            self._send(200, "ok")
+        else:
+            self._send(404, "not found")
+
+    def do_POST(self) -> None:
+        if self.path.rstrip("/") != PUSH_PATH.rstrip("/"):
+            self._send(404, "not found")
+            return
+
+        # Parse the Pub/Sub push envelope:
+        #   {"message": {"data": <base64>, "messageId": "..."}, "subscription": "..."}
+        try:
+            length = int(self.headers.get("Content-Length", 0) or 0)
+            raw = self.rfile.read(length) if length else b""
+            envelope = json.loads(raw.decode("utf-8"))
+            msg = envelope["message"]
+            data = base64.b64decode(msg.get("data", "") or "")
+            message_id = msg.get("messageId") or msg.get("message_id") or "?"
+        except Exception as e:
+            # A malformed envelope is not a real Pub/Sub delivery and will never
+            # become valid on retry -> ACK so Pub/Sub stops resending it.
+            logger.error("Bad push envelope, dropping: %s", e)
+            self._send(204)
+            return
+
+        push_msg = PushMessage(data, message_id)
+        try:
+            # All idempotency, schema-validation, poison-drop and state-machine
+            # logic lives in worker.callback() and is reused verbatim.
+            worker.callback(push_msg)
+        except Exception as e:
+            # callback() manages its own ack/nack, but guard against anything
+            # that escapes so Pub/Sub retries rather than silently dropping.
+            logger.exception("Unhandled error in worker.callback: %s", e)
+            self._send(503, "retry")
+            return
+
+        if push_msg.result == "nack":
+            self._send(503, "retry")  # transient failure -> redeliver
+        elif push_msg.result == "ack":
+            self._send(204)  # success, or a poison message we chose to drop
+        else:
+            # callback() returned without acking/nacking (shouldn't happen).
+            # Treat as transient and let Pub/Sub retry.
+            logger.warning("callback() left message %s un-acked; NACKing", message_id)
+            self._send(503, "retry")
+
+    def log_message(self, fmt, *args):  # noqa: A003 - override stdlib hook
+        # Suppress the default per-request stderr line; we log meaningfully above.
+        return
+
+
+def main() -> None:
+    port = int(os.getenv("PORT", "8080"))
+    server = ThreadingHTTPServer(("0.0.0.0", port), Handler)
+    logger.info(
+        "worker_http listening on :%s (mode=%s, push_path=%s)",
+        port, worker._processing_mode, PUSH_PATH,
+    )
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/worker_http.py
+++ b/worker_http.py
@@ -134,11 +134,21 @@ class Handler(BaseHTTPRequestHandler):
             envelope = json.loads(raw.decode("utf-8"))
             msg = envelope["message"]
             data = base64.b64decode(msg.get("data", "") or "")
-            message_id = msg.get("messageId") or msg.get("message_id") or "?"
+            message_id = msg.get("messageId") or msg.get("message_id")
         except Exception as e:
             # A malformed envelope is not a real Pub/Sub delivery and will never
             # become valid on retry -> ACK so Pub/Sub stops resending it.
             logger.error("Bad push envelope, dropping: %s", e)
+            self._send(204)
+            return
+
+        if not message_id:
+            # Real Pub/Sub push always sets messageId. Without it,
+            # worker.callback()'s idempotency marker (keyed on message_id) would
+            # collide across deliveries -- distinct messages sharing a blank id
+            # would be wrongly de-duplicated. Treat as a malformed envelope and
+            # drop it (ACK) rather than processing under a bogus id.
+            logger.error("Push envelope missing messageId, dropping")
             self._send(204)
             return
 
@@ -169,7 +179,27 @@ class Handler(BaseHTTPRequestHandler):
         return
 
 
+def _validate_config() -> None:
+    """Fail fast on startup if required runtime config is missing.
+
+    Without this the service would start fine and then NACK (503) every
+    delivery forever, triggering a Pub/Sub redelivery storm that is hard to
+    diagnose. SUBSCRIPTION_ID is intentionally NOT required here -- in push
+    mode the worker never subscribes; Pub/Sub pushes to it.
+    """
+    required = {
+        "GOOGLE_CLOUD_PROJECT": os.getenv("GOOGLE_CLOUD_PROJECT"),
+        "GCS_BUCKET_NAME": os.getenv("GCS_BUCKET_NAME"),
+    }
+    missing = [name for name, value in required.items() if not value]
+    if missing:
+        raise SystemExit(
+            f"worker_http: missing required env vars: {', '.join(missing)}"
+        )
+
+
 def main() -> None:
+    _validate_config()
     port = int(os.getenv("PORT", "8080"))
     server = ThreadingHTTPServer(("0.0.0.0", port), Handler)
     logger.info(


### PR DESCRIPTION
## What & why

Automates the autoencoder worker so jobs run without a developer's machine or an always-on VM. The worker now runs as a **private, scale-to-zero Cloud Run service** triggered by a **Pub/Sub push subscription** — idle cost ≈ $0, jobs start in seconds, no VM to babysit. Heavy jobs can be offloaded to Vertex AI by setting `WORKER_MODE=vertex` (already supported in `worker.py`).

This is a focused MVP that cuts across TASKS.md Section 11 Phases B–E.

## Changes

- **`worker_http.py`** — tiny stdlib (`http.server`) HTTP server exposing `POST /pubsub/push` and `GET /healthz`. A `PushMessage` adapter mimics the slice of the Pub/Sub `Message` API the worker uses (`.data`, `.message_id`, `.ack`, `.nack`, `.modify_ack_deadline`) so **`worker.callback()` and the entire job pipeline are reused unchanged**. The `worker.py` pull-mode CLI still works for local dev.
- **`Dockerfile.worker`** (`python:3.11-slim`) + **`cloudbuild.worker.yaml`** — builds the worker image to Artifact Registry (`gcloud builds submit --config=cloudbuild.worker.yaml --substitutions=_IMAGE=...`).
- **`.gcloudignore`** — required: `gcloud builds submit` uses `.gcloudignore`/`.gitignore` (not `.dockerignore`) to pick the upload set; without it the multi-GB local venvs get uploaded and the build hangs. **`.dockerignore`** added too.
- **`TASKS.md`** — Section 11 phase tracker updated (B–E partial) with what shipped vs. still TODO.

## Auth model

The Cloud Run service is deployed `--no-allow-unauthenticated`; only the `ae-pubsub-pusher` SA (granted `roles/run.invoker`) can invoke it, and Pub/Sub attaches an OIDC token. Auth is therefore enforced at the platform layer — no in-app token verification (noted as a follow-up).

## Infra provisioned (manually, not yet scripted)

- SAs `ae-worker` (datastore.user, storage.objectAdmin, aiplatform.user, iam.serviceAccountUser) and `ae-pubsub-pusher` (run.invoker on the worker service; Pub/Sub agent has tokenCreator on it).
- Push subscription `job-upload-topic-push` → worker `/pubsub/push` (OIDC). Pull sub `job-upload-topic-sub` kept for local dev.
- Cloud Run `worker`: `--cpu=2 --memory=4Gi --max-instances=2 --concurrency=1 --timeout=3600 --min-instances=0`.

## Verification

Verified end-to-end over `aletheia.stern.nyu.edu` with the local worker stopped: a 28,549-row upload was processed entirely by the Cloud Run worker (`Saved 100 outliers to Firestore`, push returned 204 after ~110s).

## Deferred (TASKS.md Section 11)

Dead-letter topic, in-app OIDC verification, least-privilege IAM conditions, `scripts/deploy/bootstrap.sh` + `deploy.sh`, `Dockerfile.api` / vertex-trainer rename, unified `cloudbuild.yaml`, and `tests/test_worker_http.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)